### PR TITLE
fix(android): unify account menu and guard firebase init

### DIFF
--- a/lib/core/firebase/bootstrap.dart
+++ b/lib/core/firebase/bootstrap.dart
@@ -19,9 +19,25 @@ class _FirebaseBootstrapState extends State<FirebaseBootstrap> {
   @override
   void initState() {
     super.initState();
-    _initialization = Firebase.initializeApp(
-      options: firebaseOptionsFor(widget.target),
-    );
+    _initialization = _initializeFirebase();
+  }
+
+  Future<FirebaseApp> _initializeFirebase() async {
+    final alreadyInitialized = Firebase.apps.where((app) => app.name == defaultFirebaseAppName);
+    if (alreadyInitialized.isNotEmpty) {
+      return alreadyInitialized.first;
+    }
+
+    try {
+      return await Firebase.initializeApp(
+        options: firebaseOptionsFor(widget.target),
+      );
+    } on FirebaseException catch (error) {
+      if (error.code == 'duplicate-app') {
+        return Firebase.app();
+      }
+      rethrow;
+    }
   }
 
   @override

--- a/lib/features/account/presentation/account_menu_button.dart
+++ b/lib/features/account/presentation/account_menu_button.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -51,70 +50,31 @@ class AccountMenuButton extends StatelessWidget {
     final photoUrl = (user?.photoURL ?? '').trim();
     final email = (user?.email ?? '').trim();
 
-    if (kIsWeb) {
-      return PopupMenuButton<String>(
-        tooltip: 'Mon compte',
-        onSelected: (value) async {
-          if (value == 'account') {
-            await _goToAccount(context);
-            return;
-          }
-          if (value == 'logout') {
-            await _logout(context);
-          }
-        },
-        itemBuilder: (context) => const [
-          PopupMenuItem<String>(
-            value: 'account',
-            child: Text('Mon compte'),
-          ),
-          PopupMenuItem<String>(
-            value: 'logout',
-            child: Text('Se deconnecter'),
-          ),
-        ],
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: _buildAvatar(photoUrl, email),
-        ),
-      );
-    }
-
-    return IconButton(
+    return PopupMenuButton<String>(
       tooltip: 'Mon compte',
-      onPressed: () {
-        final messenger = ScaffoldMessenger.of(context);
-        messenger.hideCurrentSnackBar();
-        messenger.showSnackBar(
-          SnackBar(
-            behavior: SnackBarBehavior.floating,
-            duration: const Duration(seconds: 8),
-            content: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Expanded(
-                  child: Row(
-                    children: [
-                      _buildAvatar(photoUrl, email),
-                      const SizedBox(width: 10),
-                      const Text('Mon compte'),
-                    ],
-                  ),
-                ),
-                TextButton(
-                  onPressed: () => _goToAccount(context),
-                  child: const Text('Compte'),
-                ),
-                TextButton(
-                  onPressed: () => _logout(context),
-                  child: const Text('Logout'),
-                ),
-              ],
-            ),
-          ),
-        );
+      onSelected: (value) async {
+        if (value == 'account') {
+          await _goToAccount(context);
+          return;
+        }
+        if (value == 'logout') {
+          await _logout(context);
+        }
       },
-      icon: _buildAvatar(photoUrl, email),
+      itemBuilder: (context) => const [
+        PopupMenuItem<String>(
+          value: 'account',
+          child: Text('Mon compte'),
+        ),
+        PopupMenuItem<String>(
+          value: 'logout',
+          child: Text('Se deconnecter'),
+        ),
+      ],
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: _buildAvatar(photoUrl, email),
+      ),
     );
   }
 }


### PR DESCRIPTION
Use the same avatar popup account menu on mobile and web, and prevent Firebase duplicate default-app initialization errors when launching preview flavor on Android.

Made-with: Cursor