### PR TITLE
Work/feat 14

### DIFF
--- a/.cursor/rules/planzers-guidelines.mdc
+++ b/.cursor/rules/planzers-guidelines.mdc
@@ -1,8 +1,13 @@
+---
+description: Planzers project guidelines — language, stack, and workflow
+alwaysApply: true
+---
+
 # Planzers — project guidelines
 
 These rules apply to everyone working on the repository, including automated coding agents.
 
-**Cursor:** The same policy is loaded automatically via [`.cursor/rules/planzers-guidelines.mdc`](.cursor/rules/planzers-guidelines.mdc) (`alwaysApply: true`). If you change these guidelines, update that file too so agents stay in sync.
+> Keep this file aligned with `GUIDELINES.md` at the repository root (same policy). When you change policy, update both.
 
 ## Language
 
@@ -30,5 +35,5 @@ These rules apply to everyone working on the repository, including automated cod
 
 ## AI / agent usage
 
-- Read this file at the start of substantive work on the repo.
+- Apply this document from the first step of any task in this repo.
 - Obey user instructions that override or refine these defaults when they conflict.

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -1,0 +1,32 @@
+# Planzers — project guidelines
+
+These rules apply to everyone working on the repository, including automated coding agents.
+
+## Language
+
+- **Commit messages:** English only. Use clear, imperative-style subjects (e.g. `feat(trips): add expense list screen`).
+- **Source code:** English for identifiers, file names, and in-code documentation (`//`, `///`).
+- **Comments:** English only.
+- **User-facing copy:** Follow the product language (currently French for UI strings and SnackBars). Do not translate the app to English in code unless explicitly requested.
+
+## Engineering
+
+- Prefer small, focused changes. Avoid drive-by refactors unrelated to the task.
+- Match existing patterns in the codebase (structure, naming, state management, routing).
+- After non-trivial edits, run `flutter analyze` and fix new issues.
+
+## Stack (reference)
+
+- **Flutter / Dart** with **Riverpod** for state.
+- **go_router** for navigation (including nested / shell routes where appropriate).
+- **Firebase** (Auth, Firestore, Functions, etc.) — follow existing repository and security patterns.
+
+## Pull requests and reviews
+
+- Describe what changed and why in complete sentences.
+- Link issues or tickets when applicable.
+
+## AI / agent usage
+
+- Read this file at the start of substantive work on the repo.
+- Obey user instructions that override or refine these defaults when they conflict.

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,11 +1,10 @@
-import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:planzers/features/account/presentation/account_page.dart';
 import 'package:planzers/features/auth/auth_gate.dart';
 import 'package:planzers/features/auth/sign_in_page.dart';
-import 'package:planzers/features/trips/data/trip.dart';
 import 'package:planzers/features/trips/presentation/invite_join_page.dart';
-import 'package:planzers/features/trips/presentation/trip_details_page.dart';
+import 'package:planzers/features/trips/presentation/trip_overview_page.dart';
+import 'package:planzers/features/trips/presentation/trip_shell_page.dart';
 import 'package:planzers/features/trips/presentation/trips_page.dart';
 
 final GoRouter appRouter = GoRouter(
@@ -39,24 +38,74 @@ final GoRouter appRouter = GoRouter(
     ),
     GoRoute(
       path: '/trips/:tripId',
-      builder: (context, state) {
-        final extra = state.extra;
-        final trip = extra is Trip ? extra : null;
-        if (trip == null) {
-          return const Scaffold(
-            body: Center(
-              child: Padding(
-                padding: EdgeInsets.all(24),
-                child: Text(
-                  'Voyage introuvable (donnees manquantes).',
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            ),
-          );
+      redirect: (context, state) {
+        final segs = state.uri.pathSegments;
+        if (segs.length == 2) {
+          return '/trips/${state.pathParameters['tripId']}/overview';
         }
-        return TripDetailsPage(trip: trip);
+        return null;
       },
+      routes: <RouteBase>[
+        StatefulShellRoute.indexedStack(
+          builder: (context, state, navigationShell) {
+            final tripId = state.pathParameters['tripId']!;
+            return TripShellPage(
+              tripId: tripId,
+              navigationShell: navigationShell,
+            );
+          },
+          branches: <StatefulShellBranch>[
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: 'overview',
+                  builder: (context, state) => const TripOverviewPage(),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: 'expenses',
+                  builder: (context, state) => const TripExpensesPage(),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: 'rooms',
+                  builder: (context, state) => const TripRoomsPage(),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: 'cars',
+                  builder: (context, state) => const TripCarsPage(),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: 'meals',
+                  builder: (context, state) => const TripMealsPage(),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: <RouteBase>[
+                GoRoute(
+                  path: 'activities',
+                  builder: (context, state) => const TripActivitiesPage(),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
     ),
   ],
 );

--- a/lib/features/trips/data/trips_repository.dart
+++ b/lib/features/trips/data/trips_repository.dart
@@ -17,6 +17,12 @@ final tripsStreamProvider = StreamProvider<List<Trip>>((ref) {
   return ref.watch(tripsRepositoryProvider).watchMyTrips();
 });
 
+/// Single trip document stream (for trip hub shell and deep links).
+final tripStreamProvider =
+    StreamProvider.autoDispose.family<Trip?, String>((ref, tripId) {
+  return ref.watch(tripsRepositoryProvider).watchTrip(tripId);
+});
+
 class TripsRepository {
   TripsRepository({
     required this.firestore,
@@ -46,6 +52,24 @@ class TripsRepository {
     final now = DateTime.now().microsecondsSinceEpoch.toString();
     final uid = auth.currentUser?.uid ?? 'anon';
     return sha256.convert('$uid-$now'.codeUnits).toString().substring(0, 32);
+  }
+
+  Stream<Trip?> watchTrip(String tripId) {
+    final cleanId = tripId.trim();
+    if (cleanId.isEmpty) {
+      return Stream.value(null);
+    }
+
+    return firestore.collection('trips').doc(cleanId).snapshots().map((snap) {
+      if (!snap.exists) {
+        return null;
+      }
+      final data = snap.data();
+      if (data == null) {
+        return null;
+      }
+      return Trip.fromMap(snap.id, data);
+    });
   }
 
   Stream<List<Trip>> watchMyTrips() {

--- a/lib/features/trips/presentation/trip_overview_page.dart
+++ b/lib/features/trips/presentation/trip_overview_page.dart
@@ -1,29 +1,23 @@
-import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:planzers/features/account/presentation/account_menu_button.dart';
 import 'package:planzers/features/trips/data/trip.dart';
 import 'package:planzers/features/trips/data/trips_repository.dart';
+import 'package:planzers/features/trips/presentation/trip_scope.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class TripDetailsPage extends ConsumerStatefulWidget {
-  const TripDetailsPage({
-    super.key,
-    required this.trip,
-  });
-
-  final Trip trip;
+class TripOverviewPage extends ConsumerStatefulWidget {
+  const TripOverviewPage({super.key});
 
   @override
-  ConsumerState<TripDetailsPage> createState() => _TripDetailsPageState();
+  ConsumerState<TripOverviewPage> createState() => _TripOverviewPageState();
 }
 
-class _TripDetailsPageState extends ConsumerState<TripDetailsPage> {
+class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
   final _formKey = GlobalKey<FormState>();
-  late Trip _trip;
   late final TextEditingController _titleController;
   late final TextEditingController _destinationController;
   late final TextEditingController _addressController;
@@ -33,14 +27,27 @@ class _TripDetailsPageState extends ConsumerState<TripDetailsPage> {
   bool _isSharingInvite = false;
   final Set<String> _removingMemberIds = <String>{};
 
+  Trip get _trip => TripScope.of(context);
+
   @override
   void initState() {
     super.initState();
-    _trip = widget.trip;
-    _titleController = TextEditingController(text: _trip.title);
-    _destinationController = TextEditingController(text: _trip.destination);
-    _addressController = TextEditingController(text: _trip.address);
-    _linkController = TextEditingController(text: _trip.linkUrl);
+    _titleController = TextEditingController();
+    _destinationController = TextEditingController();
+    _addressController = TextEditingController();
+    _linkController = TextEditingController();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final trip = TripScope.of(context);
+    if (!_isEditing) {
+      _titleController.text = trip.title;
+      _destinationController.text = trip.destination;
+      _addressController.text = trip.address;
+      _linkController.text = trip.linkUrl;
+    }
   }
 
   @override
@@ -53,22 +60,24 @@ class _TripDetailsPageState extends ConsumerState<TripDetailsPage> {
   }
 
   void _startEditing() {
+    final trip = TripScope.of(context);
     setState(() {
       _isEditing = true;
-      _titleController.text = _trip.title;
-      _destinationController.text = _trip.destination;
-      _addressController.text = _trip.address;
-      _linkController.text = _trip.linkUrl;
+      _titleController.text = trip.title;
+      _destinationController.text = trip.destination;
+      _addressController.text = trip.address;
+      _linkController.text = trip.linkUrl;
     });
   }
 
   void _cancelEditing() {
+    final trip = TripScope.of(context);
     setState(() {
       _isEditing = false;
-      _titleController.text = _trip.title;
-      _destinationController.text = _trip.destination;
-      _addressController.text = _trip.address;
-      _linkController.text = _trip.linkUrl;
+      _titleController.text = trip.title;
+      _destinationController.text = trip.destination;
+      _addressController.text = trip.address;
+      _linkController.text = trip.linkUrl;
     });
   }
 
@@ -118,19 +127,7 @@ class _TripDetailsPageState extends ConsumerState<TripDetailsPage> {
           );
 
       if (!mounted) return;
-      setState(() {
-        _trip = Trip(
-          id: _trip.id,
-          title: title,
-          destination: destination,
-          address: address,
-          linkUrl: linkUrl,
-          ownerId: _trip.ownerId,
-          memberIds: _trip.memberIds,
-          createdAt: _trip.createdAt,
-        );
-        _isEditing = false;
-      });
+      setState(() => _isEditing = false);
 
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Voyage mis a jour')),
@@ -226,7 +223,6 @@ class _TripDetailsPageState extends ConsumerState<TripDetailsPage> {
 
   @override
   Widget build(BuildContext context) {
-    final titleForAppBar = _trip.title.isEmpty ? 'Voyage' : _trip.title;
     final myUid = FirebaseAuth.instance.currentUser?.uid;
     final canEdit = (myUid != null && myUid == _trip.ownerId);
     final tripDocStream = FirebaseFirestore.instance
@@ -234,199 +230,203 @@ class _TripDetailsPageState extends ConsumerState<TripDetailsPage> {
         .doc(_trip.id)
         .snapshots();
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(titleForAppBar),
-        actions: [
-          if (_isEditing) ...[
-            IconButton(
-              tooltip: 'Annuler',
-              onPressed: _isSaving ? null : _cancelEditing,
-              icon: const Icon(Icons.close),
-            ),
-            IconButton(
-              tooltip: 'Enregistrer',
-              onPressed: _isSaving ? null : _save,
-              icon: _isSaving
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.check),
-            ),
-          ] else if (canEdit) ...[
-            IconButton(
-              tooltip: 'Partager invitation',
-              onPressed: _isSharingInvite ? null : _shareInviteLink,
-              icon: _isSharingInvite
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Icon(Icons.group_add_outlined),
-            ),
-            IconButton(
-              tooltip: 'Modifier',
-              onPressed: _startEditing,
-              icon: const Icon(Icons.edit_outlined),
-            ),
-          ],
-          const AccountMenuButton(),
-        ],
-      ),
-      body: StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
-        stream: tripDocStream,
-        builder: (context, snapshot) {
-          final liveData = snapshot.data?.data();
-          final liveLinkUrl =
-              (liveData?['linkUrl'] as String?) ?? _trip.linkUrl;
-          final livePreview =
-              (liveData?['linkPreview'] as Map<String, dynamic>?) ?? const {};
-          final liveMemberIds =
-              ((liveData?['memberIds'] as List<dynamic>?) ?? _trip.memberIds)
-                  .map((id) => id.toString())
-                  .toList();
+    return StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+      stream: tripDocStream,
+      builder: (context, snapshot) {
+        final liveData = snapshot.data?.data();
+        final liveLinkUrl =
+            (liveData?['linkUrl'] as String?) ?? _trip.linkUrl;
+        final livePreview =
+            (liveData?['linkPreview'] as Map<String, dynamic>?) ?? const {};
+        final liveMemberIds =
+            ((liveData?['memberIds'] as List<dynamic>?) ?? _trip.memberIds)
+                .map((id) => id.toString())
+                .toList();
 
-          final linkUrlForUi =
-              _isEditing ? _linkController.text.trim() : liveLinkUrl.trim();
+        final linkUrlForUi =
+            _isEditing ? _linkController.text.trim() : liveLinkUrl.trim();
 
-          return ListView(
-            padding: const EdgeInsets.all(16),
-            children: [
-              if (_isEditing) ...[
-                Form(
-                  key: _formKey,
-                  child: Column(
-                    children: [
-                      TextFormField(
-                        controller: _titleController,
-                        textInputAction: TextInputAction.next,
-                        decoration: const InputDecoration(
-                          labelText: 'Titre',
-                          border: OutlineInputBorder(),
-                        ),
-                        validator: (value) {
-                          if (value == null || value.trim().isEmpty) {
-                            return 'Titre obligatoire';
-                          }
-                          return null;
-                        },
+        return ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            if (canEdit)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    if (_isEditing) ...[
+                      IconButton(
+                        tooltip: 'Annuler',
+                        onPressed: _isSaving ? null : _cancelEditing,
+                        icon: const Icon(Icons.close),
                       ),
-                      const SizedBox(height: 12),
-                      TextFormField(
-                        controller: _destinationController,
-                        textInputAction: TextInputAction.next,
-                        decoration: const InputDecoration(
-                          labelText: 'Destination',
-                          border: OutlineInputBorder(),
-                        ),
-                        validator: (value) {
-                          if (value == null || value.trim().isEmpty) {
-                            return 'Destination obligatoire';
-                          }
-                          return null;
-                        },
+                      IconButton(
+                        tooltip: 'Enregistrer',
+                        onPressed: _isSaving ? null : _save,
+                        icon: _isSaving
+                            ? const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Icon(Icons.check),
                       ),
-                      const SizedBox(height: 12),
-                      TextFormField(
-                        controller: _addressController,
-                        textInputAction: TextInputAction.next,
-                        decoration: const InputDecoration(
-                          labelText: 'Adresse',
-                          hintText: '10 Rue de Rivoli, 75001 Paris',
-                          border: OutlineInputBorder(),
-                        ),
+                    ] else ...[
+                      IconButton(
+                        tooltip: 'Partager invitation',
+                        onPressed:
+                            _isSharingInvite ? null : _shareInviteLink,
+                        icon: _isSharingInvite
+                            ? const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Icon(Icons.group_add_outlined),
                       ),
-                      const SizedBox(height: 12),
-                      TextFormField(
-                        controller: _linkController,
-                        textInputAction: TextInputAction.done,
-                        decoration: const InputDecoration(
-                          labelText: 'Lien (Airbnb, Booking, site, ...)',
-                          hintText: 'https://...',
-                          border: OutlineInputBorder(),
-                        ),
-                        keyboardType: TextInputType.url,
-                        validator: (value) {
-                          final v = (value ?? '').trim();
-                          if (v.isEmpty) return null;
-                          final uri = Uri.tryParse(v);
-                          if (uri == null || !uri.isAbsolute) {
-                            return 'Lien invalide (ex: https://...)';
-                          }
-                          if (uri.scheme != 'http' && uri.scheme != 'https') {
-                            return 'Le lien doit commencer par http(s)://';
-                          }
-                          return null;
-                        },
-                        onFieldSubmitted: (_) => _save(),
+                      IconButton(
+                        tooltip: 'Modifier',
+                        onPressed: _startEditing,
+                        icon: const Icon(Icons.edit_outlined),
                       ),
                     ],
-                  ),
-                ),
-                const SizedBox(height: 16),
-              ] else ...[
-                Text(
-                  _trip.title.isEmpty ? 'Sans titre' : _trip.title,
-                  style: Theme.of(context).textTheme.headlineSmall,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  _trip.destination.isEmpty
-                      ? 'Destination inconnue'
-                      : _trip.destination,
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 16),
-              ],
-              if (linkUrlForUi.isNotEmpty) ...[
-                _LinkPreviewCardFromFirestore(
-                  url: linkUrlForUi,
-                  preview: livePreview,
-                ),
-                const SizedBox(height: 16),
-              ],
-              Card(
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      _OwnerInfoRow(ownerId: _trip.ownerId),
-                      const SizedBox(height: 12),
-                      _InfoRow(
-                        label: 'Adresse',
-                        value: _trip.address,
-                        actionIcon: Icons.location_on_outlined,
-                        onActionPressed: _trip.address.trim().isEmpty
-                            ? null
-                            : () => _openAddressLocation(_trip.address),
-                        actionTooltip: 'Ouvrir la localisation',
-                      ),
-                      const SizedBox(height: 12),
-                      _MembersInfoRow(
-                        memberIds: liveMemberIds,
-                        currentUserId: myUid,
-                        canManageMembers: canEdit,
-                        onRemoveMember: _removeMember,
-                        isRemovingMember: (memberId) =>
-                            _removingMemberIds.contains(memberId),
-                      ),
-                      const SizedBox(height: 12),
-                      _InfoRow(
-                        label: 'Cree le',
-                        value: _trip.createdAt.toLocal().toString(),
-                      ),
-                    ],
-                  ),
+                  ],
                 ),
               ),
+            if (_isEditing) ...[
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: [
+                    TextFormField(
+                      controller: _titleController,
+                      textInputAction: TextInputAction.next,
+                      decoration: const InputDecoration(
+                        labelText: 'Titre',
+                        border: OutlineInputBorder(),
+                      ),
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'Titre obligatoire';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _destinationController,
+                      textInputAction: TextInputAction.next,
+                      decoration: const InputDecoration(
+                        labelText: 'Destination',
+                        border: OutlineInputBorder(),
+                      ),
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'Destination obligatoire';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _addressController,
+                      textInputAction: TextInputAction.next,
+                      decoration: const InputDecoration(
+                        labelText: 'Adresse',
+                        hintText: '10 Rue de Rivoli, 75001 Paris',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: _linkController,
+                      textInputAction: TextInputAction.done,
+                      decoration: const InputDecoration(
+                        labelText: 'Lien (Airbnb, Booking, site, ...)',
+                        hintText: 'https://...',
+                        border: OutlineInputBorder(),
+                      ),
+                      keyboardType: TextInputType.url,
+                      validator: (value) {
+                        final v = (value ?? '').trim();
+                        if (v.isEmpty) return null;
+                        final uri = Uri.tryParse(v);
+                        if (uri == null || !uri.isAbsolute) {
+                          return 'Lien invalide (ex: https://...)';
+                        }
+                        if (uri.scheme != 'http' && uri.scheme != 'https') {
+                          return 'Le lien doit commencer par http(s)://';
+                        }
+                        return null;
+                      },
+                      onFieldSubmitted: (_) => _save(),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+            ] else ...[
+              Text(
+                _trip.title.isEmpty ? 'Sans titre' : _trip.title,
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                _trip.destination.isEmpty
+                    ? 'Destination inconnue'
+                    : _trip.destination,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 16),
             ],
-          );
-        },
-      ),
+            if (linkUrlForUi.isNotEmpty) ...[
+              _LinkPreviewCardFromFirestore(
+                url: linkUrlForUi,
+                preview: livePreview,
+              ),
+              const SizedBox(height: 16),
+            ],
+            Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _OwnerInfoRow(ownerId: _trip.ownerId),
+                    const SizedBox(height: 12),
+                    _InfoRow(
+                      label: 'Adresse',
+                      value: _trip.address,
+                      actionIcon: Icons.location_on_outlined,
+                      onActionPressed: _trip.address.trim().isEmpty
+                          ? null
+                          : () => _openAddressLocation(_trip.address),
+                      actionTooltip: 'Ouvrir la localisation',
+                    ),
+                    const SizedBox(height: 12),
+                    _MembersInfoRow(
+                      memberIds: liveMemberIds,
+                      currentUserId: myUid,
+                      canManageMembers: canEdit,
+                      onRemoveMember: _removeMember,
+                      isRemovingMember: (memberId) =>
+                          _removingMemberIds.contains(memberId),
+                    ),
+                    const SizedBox(height: 12),
+                    _InfoRow(
+                      label: 'Cree le',
+                      value: _trip.createdAt.toLocal().toString(),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/trips/presentation/trip_scope.dart
+++ b/lib/features/trips/presentation/trip_scope.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:planzers/features/trips/data/trip.dart';
+
+/// Provides the live [Trip] for the current trip hub (shell + tab pages).
+class TripScope extends InheritedWidget {
+  const TripScope({
+    super.key,
+    required this.trip,
+    required super.child,
+  });
+
+  final Trip trip;
+
+  static Trip of(BuildContext context) {
+    final scope = context.dependOnInheritedWidgetOfExactType<TripScope>();
+    assert(scope != null, 'TripScope not found');
+    return scope!.trip;
+  }
+
+  @override
+  bool updateShouldNotify(TripScope oldWidget) =>
+      !identical(trip, oldWidget.trip);
+}

--- a/lib/features/trips/presentation/trip_shell_page.dart
+++ b/lib/features/trips/presentation/trip_shell_page.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:planzers/features/account/presentation/account_menu_button.dart';
+import 'package:planzers/features/trips/data/trips_repository.dart';
+import 'package:planzers/features/trips/presentation/trip_scope.dart';
+
+/// Width at which we show a [NavigationRail] instead of a bottom [NavigationBar].
+const double _kTripShellWideBreakpoint = 720;
+
+class TripShellPage extends ConsumerWidget {
+  const TripShellPage({
+    super.key,
+    required this.tripId,
+    required this.navigationShell,
+  });
+
+  final String tripId;
+  final StatefulNavigationShell navigationShell;
+
+  static const List<_TripNavDestination> _destinations = [
+    _TripNavDestination(
+      label: 'Aperçu',
+      icon: Icons.dashboard_outlined,
+      selectedIcon: Icons.dashboard,
+    ),
+    _TripNavDestination(
+      label: 'Dépenses',
+      icon: Icons.payments_outlined,
+      selectedIcon: Icons.payments,
+    ),
+    _TripNavDestination(
+      label: 'Chambres',
+      icon: Icons.bed_outlined,
+      selectedIcon: Icons.bed,
+    ),
+    _TripNavDestination(
+      label: 'Voitures',
+      icon: Icons.directions_car_outlined,
+      selectedIcon: Icons.directions_car,
+    ),
+    _TripNavDestination(
+      label: 'Repas',
+      icon: Icons.restaurant_outlined,
+      selectedIcon: Icons.restaurant,
+    ),
+    _TripNavDestination(
+      label: 'Activités',
+      icon: Icons.event_available_outlined,
+      selectedIcon: Icons.event_available,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tripAsync = ref.watch(tripStreamProvider(tripId));
+
+    return tripAsync.when(
+      data: (trip) {
+        if (trip == null) {
+          return Scaffold(
+            appBar: AppBar(title: const Text('Voyage')),
+            body: const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text(
+                  'Voyage introuvable ou acces refuse.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+          );
+        }
+
+        final titleForAppBar = trip.title.isEmpty ? 'Voyage' : trip.title;
+
+        return TripScope(
+          trip: trip,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final useRail =
+                  constraints.maxWidth >= _kTripShellWideBreakpoint;
+              final railExtended = constraints.maxWidth >= 900;
+
+              return Scaffold(
+                appBar: AppBar(
+                  title: Text(titleForAppBar),
+                  leading: IconButton(
+                    icon: const Icon(Icons.arrow_back),
+                    onPressed: () => context.go('/trips'),
+                    tooltip: 'Mes voyages',
+                  ),
+                  actions: const [
+                    AccountMenuButton(),
+                  ],
+                ),
+                body: Row(
+                  children: [
+                    if (useRail)
+                      NavigationRail(
+                        selectedIndex: navigationShell.currentIndex,
+                        onDestinationSelected: navigationShell.goBranch,
+                        extended: railExtended,
+                        // With extended: true, Flutter only allows none/null here;
+                        // labels still show next to icons via [NavigationRailDestination.label].
+                        labelType: railExtended
+                            ? NavigationRailLabelType.none
+                            : NavigationRailLabelType.selected,
+                        destinations: [
+                          for (final d in _destinations)
+                            NavigationRailDestination(
+                              icon: Icon(d.icon),
+                              selectedIcon: Icon(d.selectedIcon),
+                              label: Text(d.label),
+                            ),
+                        ],
+                      ),
+                    Expanded(child: navigationShell),
+                  ],
+                ),
+                bottomNavigationBar: useRail
+                    ? null
+                    : NavigationBar(
+                        selectedIndex: navigationShell.currentIndex,
+                        onDestinationSelected: navigationShell.goBranch,
+                        destinations: [
+                          for (final d in _destinations)
+                            NavigationDestination(
+                              icon: Icon(d.icon),
+                              selectedIcon: Icon(d.selectedIcon),
+                              label: d.label,
+                            ),
+                        ],
+                      ),
+              );
+            },
+          ),
+        );
+      },
+      loading: () => const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (error, _) => Scaffold(
+        appBar: AppBar(title: const Text('Voyage')),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              'Erreur: $error',
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TripNavDestination {
+  const _TripNavDestination({
+    required this.label,
+    required this.icon,
+    required this.selectedIcon,
+  });
+
+  final String label;
+  final IconData icon;
+  final IconData selectedIcon;
+}
+
+class TripExpensesPage extends StatelessWidget {
+  const TripExpensesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return _TripSectionPlaceholder(
+      title: 'Dépenses',
+      icon: Icons.payments_outlined,
+      message:
+          'Suivi des dépenses partagées pour ce voyage. Contenu à venir.',
+    );
+  }
+}
+
+class TripRoomsPage extends StatelessWidget {
+  const TripRoomsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return _TripSectionPlaceholder(
+      title: 'Chambres',
+      icon: Icons.bed_outlined,
+      message: 'Répartition des chambres et hébergements. Contenu à venir.',
+    );
+  }
+}
+
+class TripCarsPage extends StatelessWidget {
+  const TripCarsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return _TripSectionPlaceholder(
+      title: 'Voitures',
+      icon: Icons.directions_car_outlined,
+      message: 'Covoiturage et véhicules. Contenu à venir.',
+    );
+  }
+}
+
+class TripMealsPage extends StatelessWidget {
+  const TripMealsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return _TripSectionPlaceholder(
+      title: 'Repas',
+      icon: Icons.restaurant_outlined,
+      message: 'Planning des repas. Contenu à venir.',
+    );
+  }
+}
+
+class TripActivitiesPage extends StatelessWidget {
+  const TripActivitiesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return _TripSectionPlaceholder(
+      title: 'Activités',
+      icon: Icons.event_available_outlined,
+      message: 'Activités et sorties du voyage. Contenu à venir.',
+    );
+  }
+}
+
+class _TripSectionPlaceholder extends StatelessWidget {
+  const _TripSectionPlaceholder({
+    required this.title,
+    required this.icon,
+    required this.message,
+  });
+
+  final String title;
+  final IconData icon;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final trip = TripScope.of(context);
+    final tripLabel = trip.title.isEmpty ? 'Ce voyage' : trip.title;
+
+    return ListView(
+      padding: const EdgeInsets.all(24),
+      children: [
+        Icon(icon, size: 48, color: Theme.of(context).colorScheme.primary),
+        const SizedBox(height: 16),
+        Text(
+          title,
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+        const SizedBox(height: 8),
+        Text(
+          tripLabel,
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+        ),
+        const SizedBox(height: 16),
+        Text(
+          message,
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/trips/presentation/trips_page.dart
+++ b/lib/features/trips/presentation/trips_page.dart
@@ -43,7 +43,7 @@ class TripsPage extends ConsumerWidget {
               final trip = trips[index];
               final canDelete = (myUid != null && trip.ownerId == myUid);
               return ListTile(
-                onTap: () => context.push('/trips/${trip.id}', extra: trip),
+                onTap: () => context.push('/trips/${trip.id}/overview'),
                 title: Text(trip.title),
                 subtitle: Text(trip.destination),
                 trailing: Row(


### PR DESCRIPTION
This pull request introduces a new set of project guidelines for the repository and refactors the trip details routing and page structure to support a more scalable, shell-based navigation for trip-related features. It also introduces a new `TripScope` mechanism for providing live trip data to all nested trip pages, and updates state management patterns accordingly.

**Project guidelines:**

* Added `GUIDELINES.md` at the repository root and `.cursor/rules/planzers-guidelines.mdc` to define and synchronize language, engineering, stack, and workflow policies for all contributors and coding agents. These documents ensure consistency and clarify expectations for code, commit messages, and PRs. [[1]](diffhunk://#diff-22e674f3d1da91695fbafd4d2c81f91246cfabab3d16dcf6492e6024797b4da5R1-R34) [[2]](diffhunk://#diff-2bf2026cc5fcf6c7122a6ca98ece7fb7a3bdb43b70294626a4c5cffb785cf7e1R1-R39)

**Trip navigation and data flow refactor:**

* Refactored routing in `lib/app/router.dart` to use a nested shell route (`TripShellPage`) for trip-related tabs (overview, expenses, rooms, cars, meals, activities). The `/trips/:tripId` route now redirects to `/trips/:tripId/overview` and uses an `IndexedStack` for tab navigation. [[1]](diffhunk://#diff-d190caa400edf1e29eaf08930982985dafe3c94bc5aa5a7b940bfde46b355edfL1-R7) [[2]](diffhunk://#diff-d190caa400edf1e29eaf08930982985dafe3c94bc5aa5a7b940bfde46b355edfL42-R108)
* Introduced `TripScope` (`lib/features/trips/presentation/trip_scope.dart`) as an `InheritedWidget` to provide the current trip data to all nested trip tab pages, enabling consistent access to live trip information across the shell and its children.

**Trip data providers and repository:**

* Added `tripStreamProvider` (auto-dispose, family) in `lib/features/trips/data/trips_repository.dart` to stream a single trip document by ID, supporting the new shell/tab architecture. Also added a `watchTrip` method to `TripsRepository` for the same purpose. [[1]](diffhunk://#diff-09bde4d01ba0524476dc9aef5376985c9a1a9de252c1526a41ddf90b173ae7aaR20-R25) [[2]](diffhunk://#diff-09bde4d01ba0524476dc9aef5376985c9a1a9de252c1526a41ddf90b173ae7aaR57-R74)

**Trip overview page refactor:**

* Renamed and refactored `TripDetailsPage` to `TripOverviewPage`, updating it to use `TripScope` for trip data instead of constructor parameters and removing local trip state. The page now reacts to live trip data updates and is compatible with the new shell/tab structure. [[1]](diffhunk://#diff-ccd4badd91ea29233b7cc48ae069d093de08e45b94a77838d699f225dbb0d715L1-L26) [[2]](diffhunk://#diff-ccd4badd91ea29233b7cc48ae069d093de08e45b94a77838d699f225dbb0d715R30-R50) [[3]](diffhunk://#diff-ccd4badd91ea29233b7cc48ae069d093de08e45b94a77838d699f225dbb0d715R63-R80) [[4]](diffhunk://#diff-ccd4badd91ea29233b7cc48ae069d093de08e45b94a77838d699f225dbb0d715L121-R130) [[5]](diffhunk://#diff-ccd4badd91ea29233b7cc48ae069d093de08e45b94a77838d699f225dbb0d715L229-R257) [[6]](diffhunk://#diff-ccd4badd91ea29233b7cc48ae069d093de08e45b94a77838d699f225dbb0d715L254-R286) [[7]](diffhunk://#diff-ccd4badd91ea29233b7cc48ae069d093de08e45b94a77838d699f225dbb0d715L276-R298) [[8]](diffhunk://#diff-ccd4badd91ea29233b7cc48ae069d093de08e45b94a77838d699f225dbb0d715L429)