### PR TITLE
Work/feat 9

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -29,6 +29,14 @@ function pickFirst(...values) {
   return '';
 }
 
+/** Text before @ for public trip member chips (empty if unusable). */
+function emailLocalPart(email) {
+  const e = normalizeString(email);
+  if (!e) return '';
+  const at = e.indexOf('@');
+  return at > 0 ? e.slice(0, at).trim() : e;
+}
+
 async function fetchHtml(url) {
   const res = await fetch(url.toString(), {
     redirect: 'follow',
@@ -227,6 +235,69 @@ exports.joinTripWithInvite = onCall(
       });
     });
 
+    let emailLocal = '';
+    try {
+      const userRecord = await admin.auth().getUser(uid);
+      emailLocal = emailLocalPart(userRecord.email || '');
+    } catch (e) {
+      console.warn('joinTripWithInvite getUser', e);
+    }
+    if (emailLocal) {
+      await tripRef.update({
+        [`memberPublicLabels.${uid}`]: emailLocal,
+      });
+    }
+
+    return { ok: true };
+  }
+);
+
+exports.registerMyTripMemberLabel = onCall(
+  {
+    region: 'europe-west1',
+  },
+  async (request) => {
+    const uid = request.auth?.uid;
+    if (!uid) {
+      throw new HttpsError('unauthenticated', 'Utilisateur non connecte');
+    }
+
+    const tripId = normalizeString(request.data?.tripId);
+    if (!tripId) {
+      throw new HttpsError('invalid-argument', 'Voyage invalide');
+    }
+
+    const tripRef = admin.firestore().collection('trips').doc(tripId);
+    const snap = await tripRef.get();
+    if (!snap.exists) {
+      throw new HttpsError('not-found', 'Voyage introuvable');
+    }
+
+    const data = snap.data() || {};
+    const memberIds = Array.isArray(data.memberIds)
+      ? data.memberIds.map((v) => String(v))
+      : [];
+    if (!memberIds.includes(uid)) {
+      throw new HttpsError(
+        'permission-denied',
+        'Tu ne fais pas partie de ce voyage'
+      );
+    }
+
+    let emailLocal = '';
+    try {
+      const userRecord = await admin.auth().getUser(uid);
+      emailLocal = emailLocalPart(userRecord.email || '');
+    } catch (e) {
+      console.warn('registerMyTripMemberLabel getUser', e);
+    }
+    if (!emailLocal) {
+      return { ok: false, reason: 'no-email' };
+    }
+
+    await tripRef.update({
+      [`memberPublicLabels.${uid}`]: emailLocal,
+    });
     return { ok: true };
   }
 );

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -3,6 +3,7 @@ import 'package:planzers/features/account/presentation/account_page.dart';
 import 'package:planzers/features/auth/auth_gate.dart';
 import 'package:planzers/features/auth/sign_in_page.dart';
 import 'package:planzers/features/trips/presentation/invite_join_page.dart';
+import 'package:planzers/features/expenses/presentation/trip_expenses_page.dart';
 import 'package:planzers/features/trips/presentation/trip_overview_page.dart';
 import 'package:planzers/features/trips/presentation/trip_shell_page.dart';
 import 'package:planzers/features/trips/presentation/trips_page.dart';

--- a/lib/core/intl/intl_locale_setup.dart
+++ b/lib/core/intl/intl_locale_setup.dart
@@ -1,0 +1,7 @@
+import 'package:intl/date_symbol_data_local.dart';
+
+/// Required before using [DateFormat] with explicit locales (e.g. fr_FR).
+Future<void> initializeAppDateFormatting() async {
+  await initializeDateFormatting('fr_FR');
+  await initializeDateFormatting('en_US');
+}

--- a/lib/features/account/data/account_repository.dart
+++ b/lib/features/account/data/account_repository.dart
@@ -33,12 +33,44 @@ class AccountRepository {
     }
 
     final userRef = firestore.collection('users').doc(uid);
+    final trimmed = accountName.trim();
     await userRef.set({
       'account': {
-        'name': accountName.trim(),
+        'name': trimmed,
         'updatedAt': FieldValue.serverTimestamp(),
       },
       'updatedAt': FieldValue.serverTimestamp(),
     }, SetOptions(merge: true));
+
+    final tripsSnap = await firestore
+        .collection('trips')
+        .where('memberIds', arrayContains: uid)
+        .get();
+    if (tripsSnap.docs.isEmpty) {
+      return;
+    }
+
+    var batch = firestore.batch();
+    var opCount = 0;
+    for (final doc in tripsSnap.docs) {
+      if (trimmed.isEmpty) {
+        batch.update(doc.reference, {
+          'memberPublicLabels.$uid': FieldValue.delete(),
+        });
+      } else {
+        batch.update(doc.reference, {
+          'memberPublicLabels.$uid': trimmed,
+        });
+      }
+      opCount++;
+      if (opCount >= 450) {
+        await batch.commit();
+        batch = firestore.batch();
+        opCount = 0;
+      }
+    }
+    if (opCount > 0) {
+      await batch.commit();
+    }
   }
 }

--- a/lib/features/auth/data/user_display_label.dart
+++ b/lib/features/auth/data/user_display_label.dart
@@ -1,0 +1,82 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+/// Local part of [email] for compact labels (text before '@').
+///
+/// If [email] has no '@', returns the trimmed string as-is.
+String displayLabelFromEmail(String email) {
+  final e = email.trim();
+  if (e.isEmpty) return '';
+  final at = e.indexOf('@');
+  if (at <= 0) return e;
+  return e.substring(0, at).trim();
+}
+
+/// Label for a trip member (chip, expenses, etc.).
+///
+/// Prefers [account.name], then Firebase [displayName], then the local part of
+/// the best available email ([account.email], then root [email]).
+String tripMemberDisplayLabel(
+  Map<String, dynamic>? data, {
+  required String emptyFallback,
+}) {
+  if (data == null) return emptyFallback;
+
+  final account = (data['account'] as Map<String, dynamic>?) ?? const {};
+  final accountName = (account['name'] as String?)?.trim() ?? '';
+  final accountEmail = (account['email'] as String?)?.trim() ?? '';
+  final rootEmail = (data['email'] as String?)?.trim() ?? '';
+  final displayName = (data['displayName'] as String?)?.trim() ?? '';
+
+  if (accountName.isNotEmpty) return accountName;
+  if (displayName.isNotEmpty) return displayName;
+
+  final rawEmail =
+      accountEmail.isNotEmpty ? accountEmail : rootEmail;
+  if (rawEmail.isEmpty) return emptyFallback;
+
+  final local = displayLabelFromEmail(rawEmail);
+  return local.isNotEmpty ? local : rawEmail;
+}
+
+/// When the `users/{memberId}` snapshot is missing (e.g. doc absent from the
+/// query) but the member is the signed-in user, use Auth email so [resolveTripMemberDisplayLabel]
+/// can still derive a local-part label before [tripMemberPublicLabels] is filled.
+Map<String, dynamic>? tripMemberUserDataWithAuthFallback(
+  String memberId,
+  String? currentUserId,
+  Map<String, dynamic>? memberUserData,
+) {
+  if (memberUserData != null) return memberUserData;
+  if (currentUserId == null || memberId != currentUserId) return null;
+  final email = FirebaseAuth.instance.currentUser?.email?.trim() ?? '';
+  if (email.isEmpty) return null;
+  return {
+    'email': email,
+    'account': <String, dynamic>{'email': email},
+  };
+}
+
+/// Resolves a member label: profile / auth user doc first, then
+/// [tripMemberPublicLabels] from the trip document (server-written email local
+/// part, or name synced from account settings).
+String resolveTripMemberDisplayLabel({
+  required String memberId,
+  Map<String, dynamic>? userData,
+  required Map<String, String> tripMemberPublicLabels,
+  String? currentUserId,
+  required String emptyFallback,
+}) {
+  final merged = tripMemberUserDataWithAuthFallback(
+    memberId,
+    currentUserId,
+    userData,
+  );
+  final fromUser =
+      tripMemberDisplayLabel(merged, emptyFallback: '');
+  if (fromUser.isNotEmpty) return fromUser;
+
+  final fromTrip = tripMemberPublicLabels[memberId]?.trim() ?? '';
+  if (fromTrip.isNotEmpty) return fromTrip;
+
+  return emptyFallback;
+}

--- a/lib/features/expenses/data/expense.dart
+++ b/lib/features/expenses/data/expense.dart
@@ -1,0 +1,74 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Shared expense line for a trip (Firestore: `trips/{tripId}/expenses/{expenseId}`).
+class TripExpense {
+  TripExpense({
+    required this.id,
+    required this.title,
+    required this.amount,
+    required this.currency,
+    required this.paidBy,
+    required this.participantIds,
+    required this.category,
+    required this.createdAt,
+    this.createdBy,
+  });
+
+  final String id;
+  final String title;
+  final double amount;
+  /// ISO-like code, e.g. `EUR`, `USD`.
+  final String currency;
+  final String paidBy;
+  final List<String> participantIds;
+  final String category;
+  final DateTime createdAt;
+  final String? createdBy;
+
+  factory TripExpense.fromDoc(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data() ?? const <String, dynamic>{};
+    final createdAtRaw = data['createdAt'];
+    final createdAt = switch (createdAtRaw) {
+      Timestamp ts => ts.toDate(),
+      String s => DateTime.tryParse(s) ?? DateTime.now(),
+      _ => DateTime.now(),
+    };
+
+    final amountRaw = data['amount'];
+    final amount = switch (amountRaw) {
+      num n => n.toDouble(),
+      _ => 0.0,
+    };
+
+    return TripExpense(
+      id: doc.id,
+      title: (data['title'] as String?)?.trim() ?? '',
+      amount: amount,
+      currency: ((data['currency'] as String?) ?? 'EUR').trim().toUpperCase(),
+      paidBy: (data['paidBy'] as String?)?.trim() ?? '',
+      participantIds: ((data['participantIds'] as List<dynamic>?) ?? const [])
+          .map((e) => e.toString())
+          .where((id) => id.trim().isNotEmpty)
+          .toList(),
+      category: ((data['category'] as String?) ?? 'other').trim(),
+      createdAt: createdAt,
+      createdBy: (data['createdBy'] as String?)?.trim(),
+    );
+  }
+
+  Map<String, dynamic> toCreateMap({
+    required String paidBy,
+    required String createdBy,
+  }) {
+    return {
+      'title': title.trim(),
+      'amount': amount,
+      'currency': currency.trim().toUpperCase(),
+      'paidBy': paidBy.trim(),
+      'participantIds': participantIds,
+      'category': category.trim().isEmpty ? 'other' : category.trim(),
+      'createdAt': FieldValue.serverTimestamp(),
+      'createdBy': createdBy.trim(),
+    };
+  }
+}

--- a/lib/features/expenses/data/expenses_repository.dart
+++ b/lib/features/expenses/data/expenses_repository.dart
@@ -1,0 +1,124 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:planzers/features/expenses/data/expense.dart';
+import 'package:planzers/features/expenses/domain/expense_settlement.dart';
+
+final expensesRepositoryProvider = Provider<ExpensesRepository>((ref) {
+  return ExpensesRepository(
+    firestore: FirebaseFirestore.instance,
+    auth: FirebaseAuth.instance,
+  );
+});
+
+/// Live list of expenses for a trip, newest first.
+final tripExpensesStreamProvider = StreamProvider.autoDispose
+    .family<List<TripExpense>, String>((ref, tripId) {
+  return ref.watch(expensesRepositoryProvider).watchTripExpenses(tripId);
+});
+
+class ExpensesRepository {
+  ExpensesRepository({
+    required this.firestore,
+    required this.auth,
+  });
+
+  final FirebaseFirestore firestore;
+  final FirebaseAuth auth;
+
+  CollectionReference<Map<String, dynamic>> _expensesCol(String tripId) {
+    return firestore.collection('trips').doc(tripId).collection('expenses');
+  }
+
+  Stream<List<TripExpense>> watchTripExpenses(String tripId) {
+    final cleanId = tripId.trim();
+    if (cleanId.isEmpty) {
+      return Stream.value(const <TripExpense>[]);
+    }
+
+    return _expensesCol(cleanId)
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((snap) => snap.docs.map(TripExpense.fromDoc).toList());
+  }
+
+  Future<void> addExpense({
+    required String tripId,
+    required String title,
+    required double amount,
+    required String currency,
+    required String paidBy,
+    required List<String> participantIds,
+    String category = 'other',
+  }) async {
+    final user = auth.currentUser;
+    if (user == null) {
+      throw StateError('Utilisateur non connecte');
+    }
+
+    final cleanTripId = tripId.trim();
+    if (cleanTripId.isEmpty) {
+      throw StateError('Voyage invalide');
+    }
+
+    final cleanTitle = title.trim();
+    if (cleanTitle.isEmpty) {
+      throw StateError('Libelle obligatoire');
+    }
+    if (amount <= 0) {
+      throw StateError('Montant invalide');
+    }
+
+    final cleanCurrency = currency.trim().toUpperCase();
+    if (!kSupportedExpenseCurrencies.contains(cleanCurrency)) {
+      throw StateError('Devise non supportee (EUR ou USD)');
+    }
+
+    final cleanPaidBy = paidBy.trim();
+    if (cleanPaidBy.isEmpty) {
+      throw StateError('Payeur invalide');
+    }
+
+    final participants = participantIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toList();
+    if (participants.isEmpty) {
+      throw StateError('Au moins un participant');
+    }
+
+    final draft = TripExpense(
+      id: '',
+      title: cleanTitle,
+      amount: amount,
+      currency: cleanCurrency,
+      paidBy: cleanPaidBy,
+      participantIds: participants,
+      category: category,
+      createdAt: DateTime.now(),
+      createdBy: user.uid,
+    );
+
+    await _expensesCol(cleanTripId).add(
+      draft.toCreateMap(paidBy: cleanPaidBy, createdBy: user.uid),
+    );
+  }
+
+  Future<void> deleteExpense({
+    required String tripId,
+    required String expenseId,
+  }) async {
+    final user = auth.currentUser;
+    if (user == null) {
+      throw StateError('Utilisateur non connecte');
+    }
+
+    final cleanTripId = tripId.trim();
+    final cleanExpenseId = expenseId.trim();
+    if (cleanTripId.isEmpty || cleanExpenseId.isEmpty) {
+      throw StateError('Parametres invalides');
+    }
+
+    await _expensesCol(cleanTripId).doc(cleanExpenseId).delete();
+  }
+}

--- a/lib/features/expenses/domain/expense_settlement.dart
+++ b/lib/features/expenses/domain/expense_settlement.dart
@@ -1,0 +1,139 @@
+import 'package:planzers/features/expenses/data/expense.dart';
+
+/// Net balance per person in one currency (positive = others owe this person).
+typedef BalancesByCurrency = Map<String, Map<String, double>>;
+
+/// One suggested bank transfer / cash payment to settle debts.
+class SuggestedTransfer {
+  const SuggestedTransfer({
+    required this.fromUserId,
+    required this.toUserId,
+    required this.amount,
+    required this.currency,
+  });
+
+  final String fromUserId;
+  final String toUserId;
+  final double amount;
+  final String currency;
+}
+
+/// Supported expense currencies for MVP (display + separate balance buckets).
+const Set<String> kSupportedExpenseCurrencies = {'EUR', 'USD'};
+
+/// Epsilon for floating-point comparisons (cent-level).
+const double _kBalanceEpsilon = 0.009;
+
+/// Computes per-user net balance by currency from shared expenses.
+///
+/// For each expense, the amount is split equally across [participantIds];
+/// each participant is debited their share; [paidBy] is credited the full
+/// amount paid (standard Splitwise / TriCount-style model).
+BalancesByCurrency computeBalances(Iterable<TripExpense> expenses) {
+  final result = <String, Map<String, double>>{};
+
+  for (final expense in expenses) {
+    final currency = expense.currency.trim().toUpperCase();
+    if (currency.isEmpty) continue;
+
+    final participants = expense.participantIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toList();
+    if (participants.isEmpty) continue;
+
+    final paidBy = expense.paidBy.trim();
+    if (paidBy.isEmpty) continue;
+
+    final amount = expense.amount;
+    if (amount <= 0) continue;
+
+    final perPerson = amount / participants.length;
+    final bucket = result.putIfAbsent(currency, () => <String, double>{});
+
+    for (final uid in participants) {
+      bucket[uid] = (bucket[uid] ?? 0) - perPerson;
+    }
+    bucket[paidBy] = (bucket[paidBy] ?? 0) + amount;
+  }
+
+  return result;
+}
+
+/// Greedy simplification: minimal number of transfers per currency to zero balances.
+List<SuggestedTransfer> suggestTransfers(BalancesByCurrency balancesByCurrency) {
+  final transfers = <SuggestedTransfer>[];
+
+  for (final entry in balancesByCurrency.entries) {
+    final currency = entry.key;
+    final raw = entry.value;
+
+    final working = <String, double>{};
+    for (final e in raw.entries) {
+      final v = _roundMoney(e.value);
+      if (v.abs() > _kBalanceEpsilon) {
+        working[e.key] = v;
+      }
+    }
+    if (working.isEmpty) continue;
+
+    _simplifyCurrency(working, currency, transfers);
+  }
+
+  return transfers;
+}
+
+void _simplifyCurrency(
+  Map<String, double> balances,
+  String currency,
+  List<SuggestedTransfer> out,
+) {
+  while (true) {
+    String? maxCreditor;
+    double maxCredit = 0;
+    String? maxDebtor;
+    double maxDebt = 0;
+
+    for (final e in balances.entries) {
+      if (e.value > maxCredit) {
+        maxCredit = e.value;
+        maxCreditor = e.key;
+      }
+      if (e.value < maxDebt) {
+        maxDebt = e.value;
+        maxDebtor = e.key;
+      }
+    }
+
+    if (maxCreditor == null ||
+        maxDebtor == null ||
+        maxCredit <= _kBalanceEpsilon ||
+        maxDebt >= -_kBalanceEpsilon) {
+      break;
+    }
+
+    final pay = _roundMoney(
+      maxCredit < -maxDebt ? maxCredit : -maxDebt,
+    );
+    if (pay <= _kBalanceEpsilon) break;
+
+    out.add(SuggestedTransfer(
+      fromUserId: maxDebtor,
+      toUserId: maxCreditor,
+      amount: pay,
+      currency: currency,
+    ));
+
+    balances[maxCreditor] = _roundMoney(maxCredit - pay);
+    balances[maxDebtor] = _roundMoney(maxDebt + pay);
+
+    if (balances[maxCreditor]!.abs() <= _kBalanceEpsilon) {
+      balances.remove(maxCreditor);
+    }
+    if (balances[maxDebtor]!.abs() <= _kBalanceEpsilon) {
+      balances.remove(maxDebtor);
+    }
+  }
+}
+
+double _roundMoney(double value) => (value * 100).round() / 100;

--- a/lib/features/expenses/presentation/trip_expenses_page.dart
+++ b/lib/features/expenses/presentation/trip_expenses_page.dart
@@ -1,0 +1,772 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:planzers/features/expenses/data/expense.dart';
+import 'package:planzers/features/expenses/data/expenses_repository.dart';
+import 'package:planzers/features/expenses/domain/expense_settlement.dart';
+import 'package:planzers/features/trips/presentation/trip_scope.dart';
+
+class TripExpensesPage extends ConsumerWidget {
+  const TripExpensesPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final trip = TripScope.of(context);
+    final expensesAsync = ref.watch(tripExpensesStreamProvider(trip.id));
+
+    return Scaffold(
+      body: expensesAsync.when(
+        data: (expenses) {
+          return _TripExpensesBody(
+            tripId: trip.id,
+            memberIds: trip.memberIds,
+            expenses: expenses,
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text('Erreur: $e', textAlign: TextAlign.center),
+          ),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _openAddExpenseSheet(context, ref, trip.id, trip.memberIds),
+        icon: const Icon(Icons.add),
+        label: const Text('Ajouter une dépense'),
+      ),
+    );
+  }
+
+  static Future<void> _openAddExpenseSheet(
+    BuildContext context,
+    WidgetRef ref,
+    String tripId,
+    List<String> memberIds,
+  ) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (context) => Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.viewInsetsOf(context).bottom,
+        ),
+        child: _AddExpenseSheet(
+          tripId: tripId,
+          memberIds: memberIds,
+          onSubmit: () => Navigator.of(context).pop(),
+        ),
+      ),
+    );
+  }
+}
+
+class _TripExpensesBody extends StatelessWidget {
+  const _TripExpensesBody({
+    required this.tripId,
+    required this.memberIds,
+    required this.expenses,
+  });
+
+  final String tripId;
+  final List<String> memberIds;
+  final List<TripExpense> expenses;
+
+  @override
+  Widget build(BuildContext context) {
+    final cleanMemberIds = memberIds
+        .map((id) => id.trim())
+        .where((id) => id.isNotEmpty)
+        .toList();
+
+    final balances = computeBalances(expenses);
+    final transfers = suggestTransfers(balances);
+
+    if (cleanMemberIds.isEmpty) {
+      return _buildScrollView(context, const {}, balances, transfers);
+    }
+
+    return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+      stream: FirebaseFirestore.instance
+          .collection('users')
+          .where(FieldPath.documentId, whereIn: cleanMemberIds)
+          .snapshots(),
+      builder: (context, snapshot) {
+        final labels = _labelsFromUserSnapshot(snapshot.data, cleanMemberIds);
+
+        return _buildScrollView(context, labels, balances, transfers);
+      },
+    );
+  }
+
+  Widget _buildScrollView(
+    BuildContext context,
+    Map<String, String> labels,
+    BalancesByCurrency balances,
+    List<SuggestedTransfer> transfers,
+  ) {
+    return CustomScrollView(
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+              sliver: SliverToBoxAdapter(
+                child: Text(
+                  'Dépenses',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              sliver: SliverToBoxAdapter(
+                child: _SettlementSection(
+                  balancesByCurrency: balances,
+                  transfers: transfers,
+                  memberLabels: labels,
+                ),
+              ),
+            ),
+            const SliverPadding(
+              padding: EdgeInsets.only(top: 8),
+              sliver: SliverToBoxAdapter(child: Divider(height: 1)),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+              sliver: SliverToBoxAdapter(
+                child: Text(
+                  'Opérations',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+              ),
+            ),
+            if (expenses.isEmpty)
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                sliver: SliverToBoxAdapter(
+                  child: Text(
+                    'Aucune dépense pour le moment. Utilise le bouton ci-dessous pour en ajouter une.',
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                  ),
+                ),
+              )
+            else
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                sliver: SliverList.separated(
+                  itemCount: expenses.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 8),
+                  itemBuilder: (context, index) {
+                    final expense = expenses[index];
+                    return _ExpenseCard(
+                      tripId: tripId,
+                      expense: expense,
+                      memberLabels: labels,
+                    );
+                  },
+                ),
+              ),
+            const SliverPadding(padding: EdgeInsets.only(bottom: 88)),
+          ],
+        );
+  }
+}
+
+Map<String, String> _labelsFromUserSnapshot(
+  QuerySnapshot<Map<String, dynamic>>? snapshot,
+  List<String> memberIds,
+) {
+  final docsById = <String, Map<String, dynamic>>{};
+  for (final doc in snapshot?.docs ?? const []) {
+    docsById[doc.id] = doc.data();
+  }
+
+  final labels = <String, String>{};
+  for (final memberId in memberIds) {
+    final data = docsById[memberId];
+    labels[memberId] = _displayNameFromUserData(data, fallback: 'Voyageur');
+  }
+  return labels;
+}
+
+String _displayNameFromUserData(Map<String, dynamic>? data, {required String fallback}) {
+  if (data == null) return fallback;
+  final account = (data['account'] as Map<String, dynamic>?) ?? const {};
+  final accountName = (account['name'] as String?)?.trim() ?? '';
+  final accountEmail = (account['email'] as String?)?.trim() ?? '';
+  final email = (data['email'] as String?)?.trim() ?? '';
+  final displayName = (data['displayName'] as String?)?.trim() ?? '';
+
+  if (accountName.isNotEmpty) return accountName;
+  if (accountEmail.isNotEmpty) return accountEmail;
+  if (displayName.isNotEmpty) return displayName;
+  if (email.isNotEmpty) return email;
+  return fallback;
+}
+
+String _formatMoney(String currency, double amount) {
+  final c = currency.trim().toUpperCase();
+  if (c == 'EUR') {
+    return NumberFormat.currency(locale: 'fr_FR', symbol: '€').format(amount);
+  }
+  if (c == 'USD') {
+    return NumberFormat.currency(locale: 'en_US', symbol: r'$').format(amount);
+  }
+  return '$amount $c';
+}
+
+class _SettlementSection extends StatelessWidget {
+  const _SettlementSection({
+    required this.balancesByCurrency,
+    required this.transfers,
+    required this.memberLabels,
+  });
+
+  final BalancesByCurrency balancesByCurrency;
+  final List<SuggestedTransfer> transfers;
+  final Map<String, String> memberLabels;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.balance_outlined, color: colorScheme.primary),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Soldes (par devise)',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (balancesByCurrency.isEmpty)
+                  Text(
+                    'Ajoute des dépenses pour voir la répartition.',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                  )
+                else
+                  ...balancesByCurrency.entries.map((currencyEntry) {
+                    final currency = currencyEntry.key;
+                    final perUser = currencyEntry.value;
+                    if (perUser.isEmpty) {
+                      return const SizedBox.shrink();
+                    }
+                    final sortedIds = perUser.keys.toList()..sort();
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 12),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            currency,
+                            style: Theme.of(context).textTheme.labelLarge,
+                          ),
+                          const SizedBox(height: 4),
+                          ...sortedIds.map((uid) {
+                            final bal = perUser[uid] ?? 0;
+                            final label = memberLabels[uid] ?? 'Voyageur';
+                            final isCreditor = bal > 0.009;
+                            final isDebtor = bal < -0.009;
+                            final tone = isCreditor
+                                ? colorScheme.primary
+                                : isDebtor
+                                    ? colorScheme.error
+                                    : colorScheme.onSurfaceVariant;
+                            final prefix = isCreditor
+                                ? 'À recevoir'
+                                : isDebtor
+                                    ? 'À payer'
+                                    : 'Équilibré';
+                            return Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 2),
+                              child: Row(
+                                children: [
+                                  Expanded(child: Text(label)),
+                                  Text(
+                                    '$prefix · ${_formatMoney(currency, bal.abs())}',
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodyMedium
+                                        ?.copyWith(
+                                          color: tone,
+                                          fontWeight: FontWeight.w500,
+                                        ),
+                                  ),
+                                ],
+                              ),
+                            );
+                          }),
+                        ],
+                      ),
+                    );
+                  }),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.sync_alt, color: colorScheme.primary),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        'Remboursements suggérés',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  'Nombre minimal de virements pour équilibrer les comptes (par devise).',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                ),
+                const SizedBox(height: 12),
+                if (transfers.isEmpty)
+                  Text(
+                    balancesByCurrency.isEmpty
+                        ? 'Pas encore de calcul.'
+                        : 'Tout est équilibré.',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                  )
+                else
+                  ...transfers.map((t) {
+                    final fromL = memberLabels[t.fromUserId] ?? 'Voyageur';
+                    final toL = memberLabels[t.toUserId] ?? 'Voyageur';
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 6),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Icon(Icons.arrow_forward, size: 18),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              '$fromL donne ${_formatMoney(t.currency, t.amount)} à $toL',
+                              style: Theme.of(context).textTheme.bodyMedium,
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ExpenseCard extends ConsumerStatefulWidget {
+  const _ExpenseCard({
+    required this.tripId,
+    required this.expense,
+    required this.memberLabels,
+  });
+
+  final String tripId;
+  final TripExpense expense;
+  final Map<String, String> memberLabels;
+
+  @override
+  ConsumerState<_ExpenseCard> createState() => _ExpenseCardState();
+}
+
+class _ExpenseCardState extends ConsumerState<_ExpenseCard> {
+  bool _deleting = false;
+
+  Future<void> _confirmDelete() async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Supprimer cette dépense ?'),
+        content: Text('« ${widget.expense.title} » sera supprimée.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Annuler'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Supprimer'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true || !mounted) return;
+
+    setState(() => _deleting = true);
+    try {
+      await ref.read(expensesRepositoryProvider).deleteExpense(
+            tripId: widget.tripId,
+            expenseId: widget.expense.id,
+          );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Dépense supprimée')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Erreur: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _deleting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final e = widget.expense;
+    final paidByLabel = widget.memberLabels[e.paidBy] ?? 'Voyageur';
+    final participantLabels = e.participantIds
+        .map((id) => widget.memberLabels[id] ?? 'Voyageur')
+        .join(', ');
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        e.title.isEmpty ? 'Sans titre' : e.title,
+                        style: Theme.of(context).textTheme.titleSmall,
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        _formatMoney(e.currency, e.amount),
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              color: Theme.of(context).colorScheme.primary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  tooltip: 'Supprimer',
+                  onPressed: _deleting ? null : _confirmDelete,
+                  icon: _deleting
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.delete_outline),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Payé par $paidByLabel',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            Text(
+              'Partagée entre : $participantLabels',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AddExpenseSheet extends ConsumerStatefulWidget {
+  const _AddExpenseSheet({
+    required this.tripId,
+    required this.memberIds,
+    required this.onSubmit,
+  });
+
+  final String tripId;
+  final List<String> memberIds;
+  final VoidCallback onSubmit;
+
+  @override
+  ConsumerState<_AddExpenseSheet> createState() => _AddExpenseSheetState();
+}
+
+class _AddExpenseSheetState extends ConsumerState<_AddExpenseSheet> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _amountController = TextEditingController();
+  String _currency = 'EUR';
+  String? _paidBy;
+  final Set<String> _participantIds = {};
+  bool _saving = false;
+
+  List<String> get _cleanMemberIds => widget.memberIds
+      .map((id) => id.trim())
+      .where((id) => id.isNotEmpty)
+      .toList();
+
+  @override
+  void initState() {
+    super.initState();
+    final myUid = FirebaseAuth.instance.currentUser?.uid;
+    final members = _cleanMemberIds;
+    _paidBy = (myUid != null && members.contains(myUid)) ? myUid : (members.isNotEmpty ? members.first : null);
+    _participantIds.addAll(members);
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (_saving) return;
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+
+    final paidBy = _paidBy;
+    if (paidBy == null || paidBy.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Choisis qui a payé')),
+      );
+      return;
+    }
+
+    if (_participantIds.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Coche au moins un participant')),
+      );
+      return;
+    }
+
+    final amountText = _amountController.text.trim().replaceAll(',', '.');
+    final amount = double.tryParse(amountText);
+    if (amount == null || amount <= 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Montant invalide')),
+      );
+      return;
+    }
+
+    setState(() => _saving = true);
+    try {
+      await ref.read(expensesRepositoryProvider).addExpense(
+            tripId: widget.tripId,
+            title: _titleController.text,
+            amount: amount,
+            currency: _currency,
+            paidBy: paidBy,
+            participantIds: _participantIds.toList(),
+          );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Dépense enregistrée')),
+      );
+      widget.onSubmit();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Erreur: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final members = _cleanMemberIds;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(24, 8, 24, 24),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'Nouvelle dépense',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _titleController,
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Libellé',
+                border: OutlineInputBorder(),
+              ),
+              validator: (v) {
+                if (v == null || v.trim().isEmpty) return 'Obligatoire';
+                return null;
+              },
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _amountController,
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
+              ],
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Montant',
+                border: OutlineInputBorder(),
+              ),
+              validator: (v) {
+                final t = (v ?? '').trim().replaceAll(',', '.');
+                final n = double.tryParse(t);
+                if (n == null || n <= 0) return 'Montant invalide';
+                return null;
+              },
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              key: ValueKey<String>(_currency),
+              initialValue: _currency,
+              decoration: const InputDecoration(
+                labelText: 'Devise',
+                border: OutlineInputBorder(),
+              ),
+              items: const [
+                DropdownMenuItem(value: 'EUR', child: Text('Euro (EUR)')),
+                DropdownMenuItem(value: 'USD', child: Text('Dollar (USD)')),
+              ],
+              onChanged: (v) {
+                if (v != null) setState(() => _currency = v);
+              },
+            ),
+            const SizedBox(height: 12),
+            if (members.isEmpty)
+              Text(
+                'Aucun voyageur sur ce voyage.',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+              )
+            else
+              StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                stream: FirebaseFirestore.instance
+                    .collection('users')
+                    .where(FieldPath.documentId, whereIn: members)
+                    .snapshots(),
+                builder: (context, snapshot) {
+                  final labels =
+                      _labelsFromUserSnapshot(snapshot.data, members);
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      DropdownButtonFormField<String>(
+                        key: ValueKey<String>(_paidBy ?? ''),
+                        initialValue: _paidBy != null &&
+                                members.contains(_paidBy)
+                            ? _paidBy
+                            : null,
+                        decoration: const InputDecoration(
+                          labelText: 'Payé par',
+                          border: OutlineInputBorder(),
+                        ),
+                        items: [
+                          for (final id in members)
+                            DropdownMenuItem(
+                              value: id,
+                              child: Text(
+                                labels[id] ?? id,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                        ],
+                        onChanged: (v) => setState(() => _paidBy = v),
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Partagée entre',
+                        style: Theme.of(context).textTheme.titleSmall,
+                      ),
+                      const SizedBox(height: 8),
+                      ...members.map((id) {
+                        return CheckboxListTile(
+                          value: _participantIds.contains(id),
+                          onChanged: (checked) {
+                            setState(() {
+                              if (checked == true) {
+                                _participantIds.add(id);
+                              } else {
+                                _participantIds.remove(id);
+                              }
+                            });
+                          },
+                          title: Text(
+                            labels[id] ?? id,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          dense: true,
+                          contentPadding: EdgeInsets.zero,
+                          controlAffinity: ListTileControlAffinity.leading,
+                        );
+                      }),
+                    ],
+                  );
+                },
+              ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: _saving || members.isEmpty ? null : _save,
+              child: _saving
+                  ? const SizedBox(
+                      height: 22,
+                      width: 22,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Enregistrer'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/expenses/presentation/trip_expenses_page.dart
+++ b/lib/features/expenses/presentation/trip_expenses_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:planzers/features/auth/data/user_display_label.dart';
 import 'package:planzers/features/expenses/data/expense.dart';
 import 'package:planzers/features/expenses/data/expenses_repository.dart';
 import 'package:planzers/features/expenses/domain/expense_settlement.dart';
@@ -23,6 +24,7 @@ class TripExpensesPage extends ConsumerWidget {
           return _TripExpensesBody(
             tripId: trip.id,
             memberIds: trip.memberIds,
+            memberPublicLabels: trip.memberPublicLabels,
             expenses: expenses,
           );
         },
@@ -35,7 +37,13 @@ class TripExpensesPage extends ConsumerWidget {
         ),
       ),
       floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => _openAddExpenseSheet(context, ref, trip.id, trip.memberIds),
+        onPressed: () => _openAddExpenseSheet(
+              context,
+              ref,
+              trip.id,
+              trip.memberIds,
+              trip.memberPublicLabels,
+            ),
         icon: const Icon(Icons.add),
         label: const Text('Ajouter une dépense'),
       ),
@@ -47,6 +55,7 @@ class TripExpensesPage extends ConsumerWidget {
     WidgetRef ref,
     String tripId,
     List<String> memberIds,
+    Map<String, String> memberPublicLabels,
   ) async {
     await showModalBottomSheet<void>(
       context: context,
@@ -59,6 +68,7 @@ class TripExpensesPage extends ConsumerWidget {
         child: _AddExpenseSheet(
           tripId: tripId,
           memberIds: memberIds,
+          memberPublicLabels: memberPublicLabels,
           onSubmit: () => Navigator.of(context).pop(),
         ),
       ),
@@ -70,11 +80,13 @@ class _TripExpensesBody extends StatelessWidget {
   const _TripExpensesBody({
     required this.tripId,
     required this.memberIds,
+    required this.memberPublicLabels,
     required this.expenses,
   });
 
   final String tripId;
   final List<String> memberIds;
+  final Map<String, String> memberPublicLabels;
   final List<TripExpense> expenses;
 
   @override
@@ -97,7 +109,12 @@ class _TripExpensesBody extends StatelessWidget {
           .where(FieldPath.documentId, whereIn: cleanMemberIds)
           .snapshots(),
       builder: (context, snapshot) {
-        final labels = _labelsFromUserSnapshot(snapshot.data, cleanMemberIds);
+        final labels = _labelsFromUserSnapshot(
+          snapshot.data,
+          cleanMemberIds,
+          memberPublicLabels: memberPublicLabels,
+          currentUserId: FirebaseAuth.instance.currentUser?.uid,
+        );
 
         return _buildScrollView(context, labels, balances, transfers);
       },
@@ -180,8 +197,10 @@ class _TripExpensesBody extends StatelessWidget {
 
 Map<String, String> _labelsFromUserSnapshot(
   QuerySnapshot<Map<String, dynamic>>? snapshot,
-  List<String> memberIds,
-) {
+  List<String> memberIds, {
+  String? currentUserId,
+  Map<String, String> memberPublicLabels = const {},
+}) {
   final docsById = <String, Map<String, dynamic>>{};
   for (final doc in snapshot?.docs ?? const []) {
     docsById[doc.id] = doc.data();
@@ -189,25 +208,15 @@ Map<String, String> _labelsFromUserSnapshot(
 
   final labels = <String, String>{};
   for (final memberId in memberIds) {
-    final data = docsById[memberId];
-    labels[memberId] = _displayNameFromUserData(data, fallback: 'Voyageur');
+    labels[memberId] = resolveTripMemberDisplayLabel(
+      memberId: memberId,
+      userData: docsById[memberId],
+      tripMemberPublicLabels: memberPublicLabels,
+      currentUserId: currentUserId,
+      emptyFallback: 'Voyageur',
+    );
   }
   return labels;
-}
-
-String _displayNameFromUserData(Map<String, dynamic>? data, {required String fallback}) {
-  if (data == null) return fallback;
-  final account = (data['account'] as Map<String, dynamic>?) ?? const {};
-  final accountName = (account['name'] as String?)?.trim() ?? '';
-  final accountEmail = (account['email'] as String?)?.trim() ?? '';
-  final email = (data['email'] as String?)?.trim() ?? '';
-  final displayName = (data['displayName'] as String?)?.trim() ?? '';
-
-  if (accountName.isNotEmpty) return accountName;
-  if (accountEmail.isNotEmpty) return accountEmail;
-  if (displayName.isNotEmpty) return displayName;
-  if (email.isNotEmpty) return email;
-  return fallback;
 }
 
 String _formatMoney(String currency, double amount) {
@@ -520,11 +529,13 @@ class _AddExpenseSheet extends ConsumerStatefulWidget {
   const _AddExpenseSheet({
     required this.tripId,
     required this.memberIds,
+    required this.memberPublicLabels,
     required this.onSubmit,
   });
 
   final String tripId;
   final List<String> memberIds;
+  final Map<String, String> memberPublicLabels;
   final VoidCallback onSubmit;
 
   @override
@@ -695,8 +706,12 @@ class _AddExpenseSheetState extends ConsumerState<_AddExpenseSheet> {
                     .where(FieldPath.documentId, whereIn: members)
                     .snapshots(),
                 builder: (context, snapshot) {
-                  final labels =
-                      _labelsFromUserSnapshot(snapshot.data, members);
+                  final labels = _labelsFromUserSnapshot(
+                    snapshot.data,
+                    members,
+                    memberPublicLabels: widget.memberPublicLabels,
+                    currentUserId: FirebaseAuth.instance.currentUser?.uid,
+                  );
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [

--- a/lib/features/trips/data/trip.dart
+++ b/lib/features/trips/data/trip.dart
@@ -12,6 +12,7 @@ class Trip {
     required this.createdAt,
     this.startDate,
     this.endDate,
+    this.memberPublicLabels = const {},
   });
 
   final String id;
@@ -24,6 +25,23 @@ class Trip {
   final DateTime createdAt;
   final DateTime? startDate;
   final DateTime? endDate;
+
+  /// Public display strings for members (e.g. email local part), readable by all
+  /// trip participants; populated by Cloud Functions / client on create.
+  final Map<String, String> memberPublicLabels;
+
+  static Map<String, String> memberPublicLabelsFromFirestore(dynamic raw) {
+    if (raw is! Map) return const {};
+    final out = <String, String>{};
+    raw.forEach((k, v) {
+      final key = k.toString();
+      final val = (v is String ? v : v?.toString() ?? '').trim();
+      if (key.isNotEmpty && val.isNotEmpty) {
+        out[key] = val;
+      }
+    });
+    return out;
+  }
 
   static DateTime? _parseOptionalDate(dynamic raw) {
     return switch (raw) {
@@ -54,6 +72,8 @@ class Trip {
       createdAt: createdAt,
       startDate: _parseOptionalDate(data['startDate']),
       endDate: _parseOptionalDate(data['endDate']),
+      memberPublicLabels:
+          memberPublicLabelsFromFirestore(data['memberPublicLabels']),
     );
   }
 
@@ -68,6 +88,7 @@ class Trip {
       'createdAt': createdAt.toIso8601String(),
       if (startDate != null) 'startDate': startDate!.toIso8601String(),
       if (endDate != null) 'endDate': endDate!.toIso8601String(),
+      if (memberPublicLabels.isNotEmpty) 'memberPublicLabels': memberPublicLabels,
     };
   }
 }

--- a/lib/features/trips/data/trip.dart
+++ b/lib/features/trips/data/trip.dart
@@ -10,6 +10,8 @@ class Trip {
     required this.ownerId,
     required this.memberIds,
     required this.createdAt,
+    this.startDate,
+    this.endDate,
   });
 
   final String id;
@@ -20,6 +22,16 @@ class Trip {
   final String ownerId;
   final List<String> memberIds;
   final DateTime createdAt;
+  final DateTime? startDate;
+  final DateTime? endDate;
+
+  static DateTime? _parseOptionalDate(dynamic raw) {
+    return switch (raw) {
+      Timestamp ts => ts.toDate(),
+      String s => DateTime.tryParse(s),
+      _ => null,
+    };
+  }
 
   factory Trip.fromMap(String id, Map<String, dynamic> data) {
     final createdAtRaw = data['createdAt'];
@@ -40,6 +52,8 @@ class Trip {
           .map((e) => e.toString())
           .toList(),
       createdAt: createdAt,
+      startDate: _parseOptionalDate(data['startDate']),
+      endDate: _parseOptionalDate(data['endDate']),
     );
   }
 
@@ -52,6 +66,8 @@ class Trip {
       'ownerId': ownerId,
       'memberIds': memberIds,
       'createdAt': createdAt.toIso8601String(),
+      if (startDate != null) 'startDate': startDate!.toIso8601String(),
+      if (endDate != null) 'endDate': endDate!.toIso8601String(),
     };
   }
 }

--- a/lib/features/trips/data/trips_repository.dart
+++ b/lib/features/trips/data/trips_repository.dart
@@ -95,14 +95,15 @@ class TripsRepository {
     required String destination,
     String address = '',
     String linkUrl = '',
+    DateTime? startDate,
+    DateTime? endDate,
   }) async {
     final user = auth.currentUser;
     if (user == null) {
       throw StateError('Utilisateur non connecte');
     }
 
-    final doc = firestore.collection('trips').doc();
-    await doc.set({
+    final data = <String, dynamic>{
       'title': title.trim(),
       'destination': destination.trim(),
       'address': address.trim(),
@@ -110,7 +111,16 @@ class TripsRepository {
       'ownerId': user.uid,
       'memberIds': <String>[user.uid],
       'createdAt': FieldValue.serverTimestamp(),
-    });
+    };
+    if (startDate != null) {
+      data['startDate'] = Timestamp.fromDate(startDate);
+    }
+    if (endDate != null) {
+      data['endDate'] = Timestamp.fromDate(endDate);
+    }
+
+    final doc = firestore.collection('trips').doc();
+    await doc.set(data);
   }
 
   Future<void> deleteTrip({
@@ -142,6 +152,8 @@ class TripsRepository {
     required String destination,
     required String address,
     required String linkUrl,
+    DateTime? startDate,
+    DateTime? endDate,
   }) async {
     final user = auth.currentUser;
     if (user == null) {
@@ -160,12 +172,20 @@ class TripsRepository {
       throw StateError('Seul le proprietaire peut modifier ce voyage');
     }
 
-    await docRef.update({
+    final update = <String, dynamic>{
       'title': title.trim(),
       'destination': destination.trim(),
       'address': address.trim(),
       'linkUrl': linkUrl.trim(),
-    });
+      'startDate': startDate != null
+          ? Timestamp.fromDate(startDate)
+          : FieldValue.delete(),
+      'endDate': endDate != null
+          ? Timestamp.fromDate(endDate)
+          : FieldValue.delete(),
+    };
+
+    await docRef.update(update);
   }
 
   Future<String> getOrCreateInviteLink({

--- a/lib/features/trips/data/trips_repository.dart
+++ b/lib/features/trips/data/trips_repository.dart
@@ -4,6 +4,7 @@ import 'package:crypto/crypto.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:planzers/features/auth/data/user_display_label.dart';
 import 'package:planzers/features/trips/data/trip.dart';
 
 final tripsRepositoryProvider = Provider<TripsRepository>((ref) {
@@ -103,6 +104,9 @@ class TripsRepository {
       throw StateError('Utilisateur non connecte');
     }
 
+    final ownerEmail = user.email?.trim() ?? '';
+    final ownerLabel = displayLabelFromEmail(ownerEmail);
+
     final data = <String, dynamic>{
       'title': title.trim(),
       'destination': destination.trim(),
@@ -112,6 +116,9 @@ class TripsRepository {
       'memberIds': <String>[user.uid],
       'createdAt': FieldValue.serverTimestamp(),
     };
+    if (ownerLabel.isNotEmpty) {
+      data['memberPublicLabels'] = <String, dynamic>{user.uid: ownerLabel};
+    }
     if (startDate != null) {
       data['startDate'] = Timestamp.fromDate(startDate);
     }
@@ -250,6 +257,26 @@ class TripsRepository {
     });
   }
 
+  /// Ensures this user's [memberPublicLabels] entry exists on the trip (email
+  /// local part via Admin SDK). Safe to call after join; no-op if Cloud
+  /// Function is unavailable.
+  Future<void> registerMyTripMemberLabel({required String tripId}) async {
+    final user = auth.currentUser;
+    if (user == null) {
+      return;
+    }
+    final cleanId = tripId.trim();
+    if (cleanId.isEmpty) {
+      return;
+    }
+
+    final regionFunctions =
+        FirebaseFunctions.instanceFor(region: 'europe-west1');
+    final callable =
+        regionFunctions.httpsCallable('registerMyTripMemberLabel');
+    await callable.call(<String, dynamic>{'tripId': cleanId});
+  }
+
   Future<void> removeMemberFromTrip({
     required String tripId,
     required String memberId,
@@ -281,6 +308,7 @@ class TripsRepository {
 
     await docRef.update({
       'memberIds': FieldValue.arrayRemove(<String>[cleanMemberId]),
+      'memberPublicLabels.$cleanMemberId': FieldValue.delete(),
     });
   }
 }

--- a/lib/features/trips/presentation/trip_date_format.dart
+++ b/lib/features/trips/presentation/trip_date_format.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+/// Single date for form rows, or placeholder when unset.
+String formatOptionalTripDate(DateTime? d) {
+  if (d == null) return 'Non renseignée';
+  return DateFormat.yMMMEd('fr_FR').format(d);
+}
+
+/// User-facing label for optional trip bounds (French UI).
+String formatTripDateRange(DateTime? start, DateTime? end) {
+  final fmt = DateFormat.yMMMEd('fr_FR');
+  if (start != null && end != null) {
+    return 'Du ${fmt.format(start)} au ${fmt.format(end)}';
+  }
+  if (start != null) {
+    return 'À partir du ${fmt.format(start)}';
+  }
+  if (end != null) {
+    return "Jusqu'au ${fmt.format(end)}";
+  }
+  return '';
+}
+
+/// Compares calendar days in local time.
+bool isEndBeforeStart(DateTime? start, DateTime? end) {
+  if (start == null || end == null) return false;
+  final s = DateUtils.dateOnly(start);
+  final e = DateUtils.dateOnly(end);
+  return e.isBefore(s);
+}

--- a/lib/features/trips/presentation/trip_overview_page.dart
+++ b/lib/features/trips/presentation/trip_overview_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:planzers/features/trips/data/trip.dart';
 import 'package:planzers/features/trips/data/trips_repository.dart';
+import 'package:planzers/features/trips/presentation/trip_date_format.dart';
 import 'package:planzers/features/trips/presentation/trip_scope.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -26,6 +27,8 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
   bool _isSaving = false;
   bool _isSharingInvite = false;
   final Set<String> _removingMemberIds = <String>{};
+  DateTime? _editStartDate;
+  DateTime? _editEndDate;
 
   Trip get _trip => TripScope.of(context);
 
@@ -67,6 +70,8 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
       _destinationController.text = trip.destination;
       _addressController.text = trip.address;
       _linkController.text = trip.linkUrl;
+      _editStartDate = trip.startDate;
+      _editEndDate = trip.endDate;
     });
   }
 
@@ -78,6 +83,8 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
       _destinationController.text = trip.destination;
       _addressController.text = trip.address;
       _linkController.text = trip.linkUrl;
+      _editStartDate = trip.startDate;
+      _editEndDate = trip.endDate;
     });
   }
 
@@ -111,6 +118,17 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
     final form = _formKey.currentState;
     if (form == null || !form.validate()) return;
 
+    if (isEndBeforeStart(_editStartDate, _editEndDate)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'La date de fin doit être le même jour ou après la date de début',
+          ),
+        ),
+      );
+      return;
+    }
+
     setState(() => _isSaving = true);
     try {
       final title = _titleController.text.trim();
@@ -124,6 +142,8 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
             destination: destination,
             address: address,
             linkUrl: linkUrl,
+            startDate: _editStartDate,
+            endDate: _editEndDate,
           );
 
       if (!mounted) return;
@@ -330,6 +350,92 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
                         return null;
                       },
                     ),
+                    const SizedBox(height: 8),
+                    ListTile(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('Date de début'),
+                      subtitle: Text(formatOptionalTripDate(_editStartDate)),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (_editStartDate != null)
+                            IconButton(
+                              icon: const Icon(Icons.clear),
+                              onPressed: () =>
+                                  setState(() => _editStartDate = null),
+                            ),
+                          IconButton(
+                            icon: const Icon(Icons.calendar_today_outlined),
+                            onPressed: () async {
+                              final picked = await showDatePicker(
+                                context: context,
+                                initialDate:
+                                    _editStartDate ?? DateTime.now(),
+                                firstDate: DateTime(2000),
+                                lastDate: DateTime(2100),
+                              );
+                              if (picked != null && mounted) {
+                                setState(() => _editStartDate = picked);
+                              }
+                            },
+                          ),
+                        ],
+                      ),
+                      onTap: () async {
+                        final picked = await showDatePicker(
+                          context: context,
+                          initialDate: _editStartDate ?? DateTime.now(),
+                          firstDate: DateTime(2000),
+                          lastDate: DateTime(2100),
+                        );
+                        if (picked != null && mounted) {
+                          setState(() => _editStartDate = picked);
+                        }
+                      },
+                    ),
+                    ListTile(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('Date de fin'),
+                      subtitle: Text(formatOptionalTripDate(_editEndDate)),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (_editEndDate != null)
+                            IconButton(
+                              icon: const Icon(Icons.clear),
+                              onPressed: () =>
+                                  setState(() => _editEndDate = null),
+                            ),
+                          IconButton(
+                            icon: const Icon(Icons.calendar_today_outlined),
+                            onPressed: () async {
+                              final picked = await showDatePicker(
+                                context: context,
+                                initialDate:
+                                    _editEndDate ?? _editStartDate ?? DateTime.now(),
+                                firstDate: _editStartDate ?? DateTime(2000),
+                                lastDate: DateTime(2100),
+                              );
+                              if (picked != null && mounted) {
+                                setState(() => _editEndDate = picked);
+                              }
+                            },
+                          ),
+                        ],
+                      ),
+                      onTap: () async {
+                        final picked = await showDatePicker(
+                          context: context,
+                          initialDate:
+                              _editEndDate ?? _editStartDate ?? DateTime.now(),
+                          firstDate: _editStartDate ?? DateTime(2000),
+                          lastDate: DateTime(2100),
+                        );
+                        if (picked != null && mounted) {
+                          setState(() => _editEndDate = picked);
+                        }
+                      },
+                    ),
                     const SizedBox(height: 12),
                     TextFormField(
                       controller: _addressController,
@@ -380,6 +486,26 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
                     : _trip.destination,
                 style: Theme.of(context).textTheme.titleMedium,
               ),
+              if (formatTripDateRange(_trip.startDate, _trip.endDate)
+                  .isNotEmpty) ...[
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Icon(
+                      Icons.date_range_outlined,
+                      size: 20,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        formatTripDateRange(_trip.startDate, _trip.endDate),
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
               const SizedBox(height: 16),
             ],
             if (linkUrlForUi.isNotEmpty) ...[

--- a/lib/features/trips/presentation/trip_overview_page.dart
+++ b/lib/features/trips/presentation/trip_overview_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:planzers/features/auth/data/user_display_label.dart';
 import 'package:planzers/features/trips/data/trip.dart';
 import 'package:planzers/features/trips/data/trips_repository.dart';
 import 'package:planzers/features/trips/presentation/trip_date_format.dart';
@@ -262,6 +263,12 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
             ((liveData?['memberIds'] as List<dynamic>?) ?? _trip.memberIds)
                 .map((id) => id.toString())
                 .toList();
+        final liveMemberPublicLabels = liveData != null &&
+                liveData.containsKey('memberPublicLabels')
+            ? Trip.memberPublicLabelsFromFirestore(
+                liveData['memberPublicLabels'],
+              )
+            : _trip.memberPublicLabels;
 
         final linkUrlForUi =
             _isEditing ? _linkController.text.trim() : liveLinkUrl.trim();
@@ -535,6 +542,7 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
                     const SizedBox(height: 12),
                     _MembersInfoRow(
                       memberIds: liveMemberIds,
+                      memberPublicLabels: liveMemberPublicLabels,
                       currentUserId: myUid,
                       canManageMembers: canEdit,
                       onRemoveMember: _removeMember,
@@ -624,10 +632,12 @@ class _OwnerInfoRow extends StatelessWidget {
         final displayName = (data?['displayName'] as String?)?.trim() ?? '';
         final email = (data?['email'] as String?)?.trim() ?? '';
 
+        final emailLocal =
+            email.isNotEmpty ? displayLabelFromEmail(email) : '';
         final ownerLabel = displayName.isNotEmpty
             ? displayName
             : email.isNotEmpty
-                ? email
+                ? (emailLocal.isNotEmpty ? emailLocal : email)
                 : 'Nom indisponible';
 
         return _InfoRow(label: 'Proprietaire', value: ownerLabel);
@@ -639,6 +649,7 @@ class _OwnerInfoRow extends StatelessWidget {
 class _MembersInfoRow extends StatelessWidget {
   const _MembersInfoRow({
     required this.memberIds,
+    required this.memberPublicLabels,
     required this.currentUserId,
     required this.canManageMembers,
     required this.onRemoveMember,
@@ -646,6 +657,7 @@ class _MembersInfoRow extends StatelessWidget {
   });
 
   final List<String> memberIds;
+  final Map<String, String> memberPublicLabels;
   final String? currentUserId;
   final bool canManageMembers;
   final Future<void> Function(String memberId, String memberLabel)
@@ -676,23 +688,13 @@ class _MembersInfoRow extends StatelessWidget {
 
         final chips = <Widget>[];
         for (final memberId in cleanMemberIds) {
-          final data = docsById[memberId];
-          final account =
-              (data?['account'] as Map<String, dynamic>?) ?? const {};
-          final accountName = (account['name'] as String?)?.trim() ?? '';
-          final accountEmail = (account['email'] as String?)?.trim() ?? '';
-          final email = (data?['email'] as String?)?.trim() ?? '';
-          final displayName = (data?['displayName'] as String?)?.trim() ?? '';
-
-          final label = accountName.isNotEmpty
-              ? accountName
-              : accountEmail.isNotEmpty
-                  ? accountEmail
-                  : displayName.isNotEmpty
-                      ? displayName
-                      : email.isNotEmpty
-                          ? email
-                          : 'Utilisateur';
+          final label = resolveTripMemberDisplayLabel(
+            memberId: memberId,
+            userData: docsById[memberId],
+            tripMemberPublicLabels: memberPublicLabels,
+            currentUserId: currentUserId,
+            emptyFallback: 'Utilisateur',
+          );
           final canRemoveThisMember = canManageMembers &&
               currentUserId != null &&
               memberId != currentUserId;

--- a/lib/features/trips/presentation/trip_shell_page.dart
+++ b/lib/features/trips/presentation/trip_shell_page.dart
@@ -1,9 +1,34 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:planzers/features/account/presentation/account_menu_button.dart';
+import 'package:planzers/features/trips/data/trip.dart';
 import 'package:planzers/features/trips/data/trips_repository.dart';
 import 'package:planzers/features/trips/presentation/trip_scope.dart';
+
+/// Backfill [Trip.memberPublicLabels] for the current user (e.g. voyages créés
+/// avant le déploiement des fonctions). Au plus un appel par voyage et par
+/// lancement d'app, et seulement si l'entrée est encore absente.
+final _tripMemberPublicLabelHealScheduled = <String>{};
+
+void _scheduleTripMemberPublicLabelHealIfNeeded(WidgetRef ref, Trip trip) {
+  final uid = FirebaseAuth.instance.currentUser?.uid.trim();
+  if (uid == null || uid.isEmpty) return;
+
+  final existing = trip.memberPublicLabels[uid]?.trim() ?? '';
+  if (existing.isNotEmpty) return;
+
+  final id = trip.id.trim();
+  if (id.isEmpty) return;
+  if (!_tripMemberPublicLabelHealScheduled.add(id)) return;
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    ref
+        .read(tripsRepositoryProvider)
+        .registerMyTripMemberLabel(tripId: id)
+        .catchError((Object _) {});
+  });
+}
 
 /// Width at which we show a [NavigationRail] instead of a bottom [NavigationBar].
 const double _kTripShellWideBreakpoint = 720;
@@ -73,6 +98,8 @@ class TripShellPage extends ConsumerWidget {
         }
 
         final titleForAppBar = trip.title.isEmpty ? 'Voyage' : trip.title;
+
+        _scheduleTripMemberPublicLabelHealIfNeeded(ref, trip);
 
         return TripScope(
           trip: trip,

--- a/lib/features/trips/presentation/trip_shell_page.dart
+++ b/lib/features/trips/presentation/trip_shell_page.dart
@@ -168,20 +168,6 @@ class _TripNavDestination {
   final IconData selectedIcon;
 }
 
-class TripExpensesPage extends StatelessWidget {
-  const TripExpensesPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return _TripSectionPlaceholder(
-      title: 'Dépenses',
-      icon: Icons.payments_outlined,
-      message:
-          'Suivi des dépenses partagées pour ce voyage. Contenu à venir.',
-    );
-  }
-}
-
 class TripRoomsPage extends StatelessWidget {
   const TripRoomsPage({super.key});
 

--- a/lib/features/trips/presentation/trips_page.dart
+++ b/lib/features/trips/presentation/trips_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:planzers/features/account/presentation/account_menu_button.dart';
 import 'package:planzers/features/trips/data/trips_repository.dart';
+import 'package:planzers/features/trips/presentation/trip_date_format.dart';
 
 class TripsPage extends ConsumerWidget {
   const TripsPage({super.key});
@@ -42,10 +43,15 @@ class TripsPage extends ConsumerWidget {
             itemBuilder: (context, index) {
               final trip = trips[index];
               final canDelete = (myUid != null && trip.ownerId == myUid);
+              final dateLine = formatTripDateRange(trip.startDate, trip.endDate);
               return ListTile(
                 onTap: () => context.push('/trips/${trip.id}/overview'),
                 title: Text(trip.title),
-                subtitle: Text(trip.destination),
+                subtitle: Text(
+                  dateLine.isEmpty
+                      ? trip.destination
+                      : '$dateLine\n${trip.destination}',
+                ),
                 trailing: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -89,31 +95,103 @@ class TripsPage extends ConsumerWidget {
     final titleController = TextEditingController();
     final destinationController = TextEditingController();
     String? error;
+    DateTime? startDate;
+    DateTime? endDate;
 
     await showDialog<void>(
       context: context,
       builder: (dialogContext) {
         return StatefulBuilder(
           builder: (context, setDialogState) {
+            Future<void> pickStart() async {
+              final picked = await showDatePicker(
+                context: dialogContext,
+                initialDate: startDate ?? DateTime.now(),
+                firstDate: DateTime(2000),
+                lastDate: DateTime(2100),
+              );
+              if (picked != null) {
+                setDialogState(() => startDate = picked);
+              }
+            }
+
+            Future<void> pickEnd() async {
+              final picked = await showDatePicker(
+                context: dialogContext,
+                initialDate: endDate ?? startDate ?? DateTime.now(),
+                firstDate: startDate ?? DateTime(2000),
+                lastDate: DateTime(2100),
+              );
+              if (picked != null) {
+                setDialogState(() => endDate = picked);
+              }
+            }
+
             return AlertDialog(
               title: const Text('Creer un voyage'),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  TextField(
-                    controller: titleController,
-                    decoration: const InputDecoration(labelText: 'Titre'),
-                  ),
-                  const SizedBox(height: 12),
-                  TextField(
-                    controller: destinationController,
-                    decoration: const InputDecoration(labelText: 'Destination'),
-                  ),
-                  if (error != null) ...[
+              content: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    TextField(
+                      controller: titleController,
+                      decoration: const InputDecoration(labelText: 'Titre'),
+                    ),
                     const SizedBox(height: 12),
-                    Text(error!, style: const TextStyle(color: Colors.red)),
+                    TextField(
+                      controller: destinationController,
+                      decoration: const InputDecoration(labelText: 'Destination'),
+                    ),
+                    const SizedBox(height: 12),
+                    ListTile(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('Date de début'),
+                      subtitle: Text(formatOptionalTripDate(startDate)),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (startDate != null)
+                            IconButton(
+                              icon: const Icon(Icons.clear),
+                              onPressed: () =>
+                                  setDialogState(() => startDate = null),
+                            ),
+                          IconButton(
+                            icon: const Icon(Icons.calendar_today_outlined),
+                            onPressed: pickStart,
+                          ),
+                        ],
+                      ),
+                      onTap: pickStart,
+                    ),
+                    ListTile(
+                      contentPadding: EdgeInsets.zero,
+                      title: const Text('Date de fin'),
+                      subtitle: Text(formatOptionalTripDate(endDate)),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (endDate != null)
+                            IconButton(
+                              icon: const Icon(Icons.clear),
+                              onPressed: () =>
+                                  setDialogState(() => endDate = null),
+                            ),
+                          IconButton(
+                            icon: const Icon(Icons.calendar_today_outlined),
+                            onPressed: pickEnd,
+                          ),
+                        ],
+                      ),
+                      onTap: pickEnd,
+                    ),
+                    if (error != null) ...[
+                      const SizedBox(height: 12),
+                      Text(error!, style: const TextStyle(color: Colors.red)),
+                    ],
                   ],
-                ],
+                ),
               ),
               actions: [
                 TextButton(
@@ -132,10 +210,20 @@ class TripsPage extends ConsumerWidget {
                       return;
                     }
 
+                    if (isEndBeforeStart(startDate, endDate)) {
+                      setDialogState(() {
+                        error =
+                            'La date de fin doit être le même jour ou après la date de début';
+                      });
+                      return;
+                    }
+
                     try {
                       await ref.read(tripsRepositoryProvider).createTrip(
                             title: title,
                             destination: destination,
+                            startDate: startDate,
+                            endDate: endDate,
                           );
                       if (dialogContext.mounted) {
                         Navigator.of(dialogContext).pop();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:planzers/app/app.dart';
 import 'package:planzers/core/firebase/firebase_target.dart';
+import 'package:planzers/core/intl/intl_locale_setup.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await initializeAppDateFormatting();
   runApp(
     const ProviderScope(
       child: PlanzersApp(firebaseTarget: FirebaseTarget.prod),

--- a/lib/main_preview.dart
+++ b/lib/main_preview.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:planzers/app/app.dart';
 import 'package:planzers/core/firebase/firebase_target.dart';
+import 'package:planzers/core/intl/intl_locale_setup.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await initializeAppDateFormatting();
   runApp(
     const ProviderScope(
       child: PlanzersApp(firebaseTarget: FirebaseTarget.preview),

--- a/lib/main_prod.dart
+++ b/lib/main_prod.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:planzers/app/app.dart';
 import 'package:planzers/core/firebase/firebase_target.dart';
+import 'package:planzers/core/intl/intl_locale_setup.dart';
 
-void main() {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await initializeAppDateFormatting();
   runApp(
     const ProviderScope(
       child: PlanzersApp(firebaseTarget: FirebaseTarget.prod),

--- a/test/expense_settlement_test.dart
+++ b/test/expense_settlement_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planzers/features/expenses/data/expense.dart';
+import 'package:planzers/features/expenses/domain/expense_settlement.dart';
+
+TripExpense _e({
+  required String paidBy,
+  required List<String> participants,
+  required double amount,
+  String currency = 'EUR',
+}) {
+  return TripExpense(
+    id: 'x',
+    title: 't',
+    amount: amount,
+    currency: currency,
+    paidBy: paidBy,
+    participantIds: participants,
+    category: 'other',
+    createdAt: DateTime(2026, 1, 1),
+  );
+}
+
+void main() {
+  test('equal split: payer is credited net (n-1) shares', () {
+    final expenses = [
+      _e(paidBy: 'a', participants: ['a', 'b', 'c'], amount: 90),
+    ];
+    final bal = computeBalances(expenses)['EUR']!;
+    expect(bal['a'], closeTo(60, 0.01));
+    expect(bal['b'], closeTo(-30, 0.01));
+    expect(bal['c'], closeTo(-30, 0.01));
+  });
+
+  test('suggestTransfers settles two-person debt in one payment', () {
+    final expenses = [
+      _e(paidBy: 'a', participants: ['a', 'b'], amount: 100),
+    ];
+    final transfers = suggestTransfers(computeBalances(expenses));
+    expect(transfers, hasLength(1));
+    expect(transfers.single.fromUserId, 'b');
+    expect(transfers.single.toUserId, 'a');
+    expect(transfers.single.amount, closeTo(50, 0.01));
+    expect(transfers.single.currency, 'EUR');
+  });
+
+  test('currencies are isolated', () {
+    final expenses = [
+      _e(
+        paidBy: 'a',
+        participants: ['a', 'b'],
+        amount: 100,
+        currency: 'EUR',
+      ),
+      _e(
+        paidBy: 'b',
+        participants: ['a', 'b'],
+        amount: 20,
+        currency: 'USD',
+      ),
+    ];
+    final bal = computeBalances(expenses);
+    expect(bal['EUR']!['a'], closeTo(50, 0.01));
+    expect(bal['USD']!['b'], closeTo(10, 0.01));
+  });
+}


### PR DESCRIPTION
This pull request introduces a comprehensive system for handling public display labels for trip members, and implements the backend and domain model for shared trip expenses (including balance settlement logic). It also adds supporting utilities for internationalization and updates data models to support new fields. The most important changes are grouped below.

**Trip Member Public Labels System:**

- Added logic to derive and store a public display label for each trip member, using the local part of their email (before the `@`) or their account name if available. This label is now synced to the `memberPublicLabels` field in the `trips` Firestore documents on trip creation and when users join trips, and is updated when the user changes their account name. [[1]](diffhunk://#diff-6c53bf76483f89e4e126787e25a40c3d7001cf6590b587c621e2e462cdbc8060R32-R39) [[2]](diffhunk://#diff-6c53bf76483f89e4e126787e25a40c3d7001cf6590b587c621e2e462cdbc8060R238-R300) [[3]](diffhunk://#diff-bc21bdb728f2406f1492383bd4ff41d98a47f297690f3736e047fafa5f3cdf38R36-R74) [[4]](diffhunk://#diff-1314258f7766966cd9a53f56964d4018e011e70e2567622518bc854fd685f851R13-R15) [[5]](diffhunk://#diff-1314258f7766966cd9a53f56964d4018e011e70e2567622518bc854fd685f851R26-R52) [[6]](diffhunk://#diff-1314258f7766966cd9a53f56964d4018e011e70e2567622518bc854fd685f851R73-R76) [[7]](diffhunk://#diff-1314258f7766966cd9a53f56964d4018e011e70e2567622518bc854fd685f851R89-R91) [[8]](diffhunk://#diff-09bde4d01ba0524476dc9aef5376985c9a1a9de252c1526a41ddf90b173ae7aaR7) [[9]](diffhunk://#diff-09bde4d01ba0524476dc9aef5376985c9a1a9de252c1526a41ddf90b173ae7aaR99-R130) [[10]](diffhunk://#diff-46a85bb10d40102db1c38430c4fdf7ddd7034da6988ab8359e6d72b4457684b1R1-R82)

**Shared Trip Expenses Domain and Repository:**

- Introduced the `TripExpense` model and `ExpensesRepository`, enabling creation, deletion, and live streaming of expenses per trip, with strong validation and Firestore integration. [[1]](diffhunk://#diff-4169aa39e922b3f5dbec757eb559b83f4e3919fcd211857ff6a8cd781a34cf70R1-R74) [[2]](diffhunk://#diff-08afc8a097bac8bf145dbdb18a7cfeff06041ff43c64e669db89081749518d91R1-R124)
- Added the `expense_settlement.dart` domain logic, which computes per-user balances for each currency and suggests minimal transfers to settle debts among trip members, supporting both EUR and USD.

**Trip Data Model Enhancements:**

- Extended the `Trip` model to include optional `startDate`, `endDate`, and the new `memberPublicLabels` mapping, with serialization/deserialization logic for Firestore. [[1]](diffhunk://#diff-1314258f7766966cd9a53f56964d4018e011e70e2567622518bc854fd685f851R13-R15) [[2]](diffhunk://#diff-1314258f7766966cd9a53f56964d4018e011e70e2567622518bc854fd685f851R26-R52) [[3]](diffhunk://#diff-1314258f7766966cd9a53f56964d4018e011e70e2567622518bc854fd685f851R73-R76) [[4]](diffhunk://#diff-1314258f7766966cd9a53f56964d4018e011e70e2567622518bc854fd685f851R89-R91)

**Internationalization Support:**

- Added a utility to initialize date formatting for `fr_FR` and `en_US` locales, required for correct date display and parsing.

**Routing and Integration:**

- Registered the new trip expenses page in the app router, preparing for UI integration of the expenses feature.