### PR TITLE
fix(app): enable French material localizations for date pickers

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:planzers/app/preview_environment_chrome.dart';
 import 'package:planzers/app/router.dart';
@@ -24,6 +25,13 @@ class PlanzersApp extends StatelessWidget {
           colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
           useMaterial3: true,
         ),
+        // Required for [showDatePicker] with fr_FR: default delegates only
+        // support English ([DefaultMaterialLocalizations]).
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        supportedLocales: const [
+          Locale('fr', 'FR'),
+          Locale('en', 'US'),
+        ],
         routerConfig: appRouter,
         builder: (context, child) {
           return FirebaseBootstrap(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -318,6 +318,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_riverpod:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   firebase_storage: ^13.2.0
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
   flutter_riverpod: ^3.3.1
   flutter_svg: ^2.2.4
   go_router: ^17.1.0


### PR DESCRIPTION
Date dialogs that requested French (for example when changing an expense date) showed a blank screen because the default material strings only cover English. The app now loads the standard Flutter localization delegates and declares French and English as supported locales so calendar dialogs render and label correctly.

Made-with: Cursor