### PR TITLE
Work/feat 9

### DIFF
--- a/.cursor/rules/planzers-guidelines.mdc
+++ b/.cursor/rules/planzers-guidelines.mdc
@@ -16,6 +16,7 @@ These rules apply to everyone working on the repository, including automated cod
 - **Source code:** English for identifiers, file names, and in-code documentation (`//`, `///`).
 - **Comments:** English only.
 - **User-facing copy:** Follow the product language (currently French for UI strings and SnackBars). Do not translate the app to English in code unless explicitly requested.
+- **UI copy scope (agents):** Do not add extra explanatory sentences, hints, helper text, or “did you know” copy to feature UIs unless the task explicitly asks for that wording. Stick to labels and messages that implement what was requested; the product owner will supply hints and tutorials separately when they want them.
 
 ## Engineering
 

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -11,6 +11,7 @@ These rules apply to everyone working on the repository, including automated cod
 - **Source code:** English for identifiers, file names, and in-code documentation (`//`, `///`).
 - **Comments:** English only.
 - **User-facing copy:** Follow the product language (currently French for UI strings and SnackBars). Do not translate the app to English in code unless explicitly requested.
+- **UI copy scope (agents):** Do not add extra explanatory sentences, hints, helper text, or “did you know” copy to feature UIs unless the task explicitly asks for that wording. Stick to labels and messages that implement what was requested; the product owner will supply hints and tutorials separately when they want them.
 
 ## Engineering
 

--- a/lib/features/expenses/data/expense.dart
+++ b/lib/features/expenses/data/expense.dart
@@ -1,5 +1,14 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+/// How the expense total is allocated across [participantIds].
+enum ExpenseSplitMode {
+  /// Same amount for each participant (`total / count`).
+  equal,
+
+  /// Each participant has an explicit share in [participantShares].
+  customAmounts,
+}
+
 /// Shared expense line for a trip (Firestore: `trips/{tripId}/expenses/{expenseId}`).
 class TripExpense {
   TripExpense({
@@ -14,7 +23,9 @@ class TripExpense {
     required this.createdAt,
     required this.expenseDate,
     this.createdBy,
-  });
+    this.splitMode = ExpenseSplitMode.equal,
+    Map<String, double>? participantShares,
+  }) : participantShares = participantShares ?? const {};
 
   final String id;
   final String groupId;
@@ -29,6 +40,11 @@ class TripExpense {
   final DateTime createdAt;
   final DateTime expenseDate;
   final String? createdBy;
+
+  /// When [splitMode] is [ExpenseSplitMode.customAmounts], share per participant
+  /// (same keys as [participantIds]); ignored for equal split.
+  final ExpenseSplitMode splitMode;
+  final Map<String, double> participantShares;
 
   factory TripExpense.fromDoc(DocumentSnapshot<Map<String, dynamic>> doc) {
     final data = doc.data() ?? const <String, dynamic>{};
@@ -70,6 +86,8 @@ class TripExpense {
         expenseDate.day,
       ),
       createdBy: (data['createdBy'] as String?)?.trim(),
+      splitMode: _splitModeFromFirestore(data['splitMode']),
+      participantShares: _participantSharesFromFirestore(data['participantShares']),
     );
   }
 
@@ -78,7 +96,7 @@ class TripExpense {
     required String createdBy,
     required String groupId,
   }) {
-    return {
+    final map = <String, dynamic>{
       'groupId': groupId.trim(),
       'title': title.trim(),
       'amount': amount,
@@ -91,6 +109,40 @@ class TripExpense {
       ),
       'createdAt': FieldValue.serverTimestamp(),
       'createdBy': createdBy.trim(),
+      'splitMode': splitMode == ExpenseSplitMode.customAmounts
+          ? 'custom'
+          : 'equal',
     };
+    if (splitMode == ExpenseSplitMode.customAmounts) {
+      map['participantShares'] = {
+        for (final e in participantShares.entries)
+          if (e.key.trim().isNotEmpty) e.key.trim(): e.value,
+      };
+    }
+    return map;
   }
+}
+
+ExpenseSplitMode _splitModeFromFirestore(Object? raw) {
+  final s = raw?.toString().trim().toLowerCase() ?? '';
+  if (s == 'custom' || s == 'amounts' || s == 'montants') {
+    return ExpenseSplitMode.customAmounts;
+  }
+  return ExpenseSplitMode.equal;
+}
+
+Map<String, double> _participantSharesFromFirestore(Object? raw) {
+  if (raw is! Map) return const {};
+  final out = <String, double>{};
+  for (final e in raw.entries) {
+    final k = e.key.toString().trim();
+    if (k.isEmpty) continue;
+    final v = e.value;
+    final n = switch (v) {
+      num x => x.toDouble(),
+      _ => null,
+    };
+    if (n != null) out[k] = n;
+  }
+  return out;
 }

--- a/lib/features/expenses/data/expenses_repository.dart
+++ b/lib/features/expenses/data/expenses_repository.dart
@@ -236,6 +236,8 @@ class ExpensesRepository {
         expenseDate.day,
       ),
       createdBy: user.uid,
+      splitMode: ExpenseSplitMode.equal,
+      participantShares: const {},
     );
 
     await _expensesCol(cleanTripId).add(
@@ -257,6 +259,8 @@ class ExpensesRepository {
     required List<String> participantIds,
     required DateTime expenseDate,
     String category = 'other',
+    ExpenseSplitMode splitMode = ExpenseSplitMode.equal,
+    Map<String, double>? participantShares,
   }) async {
     final user = auth.currentUser;
     if (user == null) {
@@ -295,7 +299,7 @@ class ExpensesRepository {
       throw StateError('Au moins un participant');
     }
 
-    await _expensesCol(cleanTripId).doc(cleanExpenseId).update({
+    final update = <String, dynamic>{
       'title': cleanTitle,
       'amount': amount,
       'currency': cleanCurrency,
@@ -307,7 +311,20 @@ class ExpensesRepository {
       ),
       'updatedAt': FieldValue.serverTimestamp(),
       'updatedBy': user.uid,
-    });
+    };
+
+    if (splitMode == ExpenseSplitMode.customAmounts) {
+      update['splitMode'] = 'custom';
+      update['participantShares'] = {
+        for (final id in participants)
+          id: (participantShares ?? const {})[id] ?? 0.0,
+      };
+    } else {
+      update['splitMode'] = 'equal';
+      update['participantShares'] = FieldValue.delete();
+    }
+
+    await _expensesCol(cleanTripId).doc(cleanExpenseId).update(update);
   }
 
   Future<void> deleteExpense({

--- a/lib/features/expenses/domain/expense_settlement.dart
+++ b/lib/features/expenses/domain/expense_settlement.dart
@@ -63,8 +63,8 @@ const double _kBalanceEpsilon = 0.009;
 
 /// Computes per-user net balance by currency from shared expenses.
 ///
-/// For each expense, the amount is split equally across [participantIds];
-/// each participant is debited their share; [paidBy] is credited the full
+/// For each expense, each participant is debited their share (equal split or
+/// explicit [TripExpense.participantShares]); [paidBy] is credited the full
 /// amount paid (standard Splitwise / TriCount-style model).
 BalancesByCurrency computeBalances(Iterable<TripExpense> expenses) {
   final result = <String, Map<String, double>>{};
@@ -85,16 +85,50 @@ BalancesByCurrency computeBalances(Iterable<TripExpense> expenses) {
     final amount = expense.amount;
     if (amount <= 0) continue;
 
-    final perPerson = amount / participants.length;
     final bucket = result.putIfAbsent(currency, () => <String, double>{});
 
+    final shares = _participantSharesForExpense(expense, participants);
     for (final uid in participants) {
-      bucket[uid] = (bucket[uid] ?? 0) - perPerson;
+      final share = shares[uid] ?? 0;
+      bucket[uid] = (bucket[uid] ?? 0) - share;
     }
     bucket[paidBy] = (bucket[paidBy] ?? 0) + amount;
   }
 
   return result;
+}
+
+/// Resolves owed amount per participant; falls back to equal split when needed.
+Map<String, double> _participantSharesForExpense(
+  TripExpense expense,
+  List<String> participants,
+) {
+  if (expense.splitMode != ExpenseSplitMode.customAmounts) {
+    final n = participants.length;
+    final per = n > 0 ? expense.amount / n : 0.0;
+    return {for (final id in participants) id: per};
+  }
+
+  final raw = expense.participantShares;
+  var sum = 0.0;
+  final out = <String, double>{};
+  for (final id in participants) {
+    final v = raw[id];
+    if (v == null || v < 0) {
+      return {
+        for (final uid in participants)
+          uid: participants.isEmpty ? 0.0 : expense.amount / participants.length,
+      };
+    }
+    out[id] = v;
+    sum += v;
+  }
+  if ((sum - expense.amount).abs() > 0.02) {
+    final n = participants.length;
+    final per = n > 0 ? expense.amount / n : 0.0;
+    return {for (final id in participants) id: per};
+  }
+  return out;
 }
 
 /// Greedy simplification: minimal number of transfers per currency to zero balances.

--- a/lib/features/expenses/presentation/trip_expenses_page.dart
+++ b/lib/features/expenses/presentation/trip_expenses_page.dart
@@ -330,6 +330,7 @@ class _TripExpensesBody extends StatelessWidget {
                 child: _ExpensePostCard(
                   tripId: tripId,
                   group: group,
+                  visibleGroupCount: visibleGroups.length,
                   groupExpenses: expenses
                       .where((e) => e.groupId == group.id)
                       .toList(),
@@ -352,6 +353,7 @@ class _ExpensePostCard extends ConsumerStatefulWidget {
   const _ExpensePostCard({
     required this.tripId,
     required this.group,
+    required this.visibleGroupCount,
     required this.groupExpenses,
     required this.memberIds,
     required this.memberPublicLabels,
@@ -361,6 +363,8 @@ class _ExpensePostCard extends ConsumerStatefulWidget {
 
   final String tripId;
   final TripExpenseGroup group;
+  /// When only one post is visible, it starts expanded (unless persisted state says otherwise).
+  final int visibleGroupCount;
   final List<TripExpense> groupExpenses;
   final List<String> memberIds;
   final Map<String, String> memberPublicLabels;
@@ -378,7 +382,8 @@ class _ExpensePostCardState extends ConsumerState<_ExpensePostCard> {
   @override
   void initState() {
     super.initState();
-    _expanded = widget.group.isDefault;
+    _expanded =
+        widget.group.isDefault || widget.visibleGroupCount == 1;
     ExpensePostExpansionStore.read(widget.tripId, widget.group.id).then((v) {
       if (!mounted || v == null) return;
       setState(() => _expanded = v);
@@ -533,7 +538,7 @@ class _ExpensePostCardState extends ConsumerState<_ExpensePostCard> {
             alignment: Alignment.topCenter,
             child: _expanded
                 ? Padding(
-                    padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                    padding: const EdgeInsets.fromLTRB(8, 0, 8, 10),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
@@ -562,16 +567,12 @@ class _ExpensePostCardState extends ConsumerState<_ExpensePostCard> {
                                 ),
                           )
                         else
-                          ...widget.groupExpenses.map(
-                            (e) => Padding(
-                              padding: const EdgeInsets.only(bottom: 8),
-                              child: _ExpenseCard(
-                                tripId: widget.tripId,
-                                expense: e,
-                                participantScopeMemberIds: scope,
-                                memberLabels: widget.memberLabels,
-                              ),
-                            ),
+                          ..._buildExpensesGroupedByDate(
+                            context,
+                            widget.groupExpenses,
+                            widget.tripId,
+                            scope,
+                            widget.memberLabels,
                           ),
                       ],
                     ),
@@ -648,8 +649,6 @@ String _formatSuggestedTransferLine({
 }
 
 enum _ExpenseDetailsMenuAction { edit, delete }
-
-const double _participantColumnWidth = 48;
 
 class _SettlementSection extends StatelessWidget {
   const _SettlementSection({
@@ -823,7 +822,68 @@ class _SettlementSection extends StatelessWidget {
   }
 }
 
-class _ExpenseCard extends ConsumerStatefulWidget {
+/// Operations under each post: newest days first, with a date header per calendar day.
+List<Widget> _buildExpensesGroupedByDate(
+  BuildContext context,
+  List<TripExpense> expenses,
+  String tripId,
+  List<String> participantScopeMemberIds,
+  Map<String, String> memberLabels,
+) {
+  if (expenses.isEmpty) return const [];
+
+  final sorted = [...expenses]
+    ..sort((a, b) => b.expenseDate.compareTo(a.expenseDate));
+
+  final byDay = <DateTime, List<TripExpense>>{};
+  for (final e in sorted) {
+    final day = DateTime(
+      e.expenseDate.year,
+      e.expenseDate.month,
+      e.expenseDate.day,
+    );
+    byDay.putIfAbsent(day, () => []).add(e);
+  }
+
+  final days = byDay.keys.toList()..sort((a, b) => b.compareTo(a));
+
+  final widgets = <Widget>[];
+  for (var i = 0; i < days.length; i++) {
+    final day = days[i];
+    final dayExpenses = byDay[day]!;
+
+    widgets.add(
+      Padding(
+        padding: EdgeInsets.only(top: i == 0 ? 0 : 12, bottom: 4),
+        child: Text(
+          DateFormat.yMMMEd('fr_FR').format(day),
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontWeight: FontWeight.w600,
+              ),
+        ),
+      ),
+    );
+
+    for (final e in dayExpenses) {
+      widgets.add(
+        Padding(
+          padding: const EdgeInsets.only(bottom: 4),
+          child: _ExpenseCard(
+            tripId: tripId,
+            expense: e,
+            participantScopeMemberIds: participantScopeMemberIds,
+            memberLabels: memberLabels,
+          ),
+        ),
+      );
+    }
+  }
+
+  return widgets;
+}
+
+class _ExpenseCard extends StatelessWidget {
   const _ExpenseCard({
     required this.tripId,
     required this.expense,
@@ -836,136 +896,62 @@ class _ExpenseCard extends ConsumerStatefulWidget {
   final List<String> participantScopeMemberIds;
   final Map<String, String> memberLabels;
 
-  @override
-  ConsumerState<_ExpenseCard> createState() => _ExpenseCardState();
-}
-
-class _ExpenseCardState extends ConsumerState<_ExpenseCard> {
-  bool _deleting = false;
-
-  Future<void> _openDetails() async {
+  Future<void> _openDetails(BuildContext context) async {
     await Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (context) => _ExpenseDetailsPage(
-          tripId: widget.tripId,
-          expense: widget.expense,
-          participantScopeMemberIds: widget.participantScopeMemberIds,
-          memberLabels: widget.memberLabels,
+          tripId: tripId,
+          expense: expense,
+          participantScopeMemberIds: participantScopeMemberIds,
+          memberLabels: memberLabels,
         ),
       ),
     );
   }
 
-  Future<void> _confirmDelete() async {
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Supprimer cette dépense ?'),
-        content: Text('« ${widget.expense.title} » sera supprimée.'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Annuler'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Supprimer'),
-          ),
-        ],
-      ),
-    );
-    if (ok != true || !mounted) return;
-
-    setState(() => _deleting = true);
-    try {
-      await ref.read(expensesRepositoryProvider).deleteExpense(
-            tripId: widget.tripId,
-            expenseId: widget.expense.id,
-          );
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Dépense supprimée')),
-        );
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Erreur: $e')),
-        );
-      }
-    } finally {
-      if (mounted) setState(() => _deleting = false);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    final e = widget.expense;
-    final paidByLabel = widget.memberLabels[e.paidBy] ?? 'Voyageur';
-    final participantLabels = e.participantIds
-        .map((id) => widget.memberLabels[id] ?? 'Voyageur')
-        .join(', ');
+    final e = expense;
+    final paidByLabel = memberLabels[e.paidBy] ?? 'Voyageur';
 
     return Card(
+      margin: EdgeInsets.zero,
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
-        onTap: _openDetails,
+        onTap: () => _openDetails(context),
         child: Padding(
-          padding: const EdgeInsets.all(12),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          e.title.isEmpty ? 'Sans titre' : e.title,
-                          style: Theme.of(context).textTheme.titleSmall,
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          _formatMoney(e.currency, e.amount),
-                          style: Theme.of(context)
-                              .textTheme
-                              .titleMedium
-                              ?.copyWith(
-                                color: Theme.of(context).colorScheme.primary,
-                                fontWeight: FontWeight.w600,
-                              ),
-                        ),
-                      ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      e.title.isEmpty ? 'Sans titre' : e.title,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
                     ),
-                  ),
-                  IconButton(
-                    tooltip: 'Supprimer',
-                    onPressed: _deleting ? null : _confirmDelete,
-                    icon: _deleting
-                        ? const SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.delete_outline),
-                  ),
-                ],
+                    const SizedBox(height: 2),
+                    Text(
+                      'Payé par $paidByLabel',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                    ),
+                  ],
+                ),
               ),
-              const SizedBox(height: 8),
+              const SizedBox(width: 8),
               Text(
-                'Date : ${_formatExpenseDate(e.expenseDate)}',
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-              Text(
-                'Payé par $paidByLabel',
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-              Text(
-                'Partagée entre : $participantLabels',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                _formatMoney(e.currency, e.amount),
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: Theme.of(context).colorScheme.primary,
+                      fontWeight: FontWeight.w600,
                     ),
               ),
             ],
@@ -1340,13 +1326,6 @@ class _ExpenseDetailsPageState extends ConsumerState<_ExpenseDetailsPage> {
                   ),
                 ],
               ),
-              const SizedBox(height: 8),
-              Text(
-                'Qui voit ce poste se règle dans le menu du poste (pas ici).',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-              ),
               const SizedBox(height: 16),
               Text(
                 'Partage du montant',
@@ -1362,66 +1341,29 @@ class _ExpenseDetailsPageState extends ConsumerState<_ExpenseDetailsPage> {
                 ),
                 child: Column(
                   children: [
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(12, 10, 12, 8),
-                      child: Row(
-                        children: [
-                          const Expanded(child: Text('Voyageur')),
-                          SizedBox(
-                            width: _participantColumnWidth,
-                            child: Center(
-                              child: Tooltip(
-                                message: 'Partage',
-                                child: Icon(
-                                  Icons.payments_outlined,
-                                  size: 18,
-                                  color: Theme.of(context).colorScheme.primary,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    const Divider(height: 1),
-                    ...members.map((id) {
-                      final canEdit = _editing;
-                      return Padding(
-                        padding: const EdgeInsets.symmetric(
+                    for (final id in members)
+                      CheckboxListTile(
+                        contentPadding: const EdgeInsets.symmetric(
                           horizontal: 12,
-                          vertical: 2,
                         ),
-                        child: Row(
-                          children: [
-                            Expanded(
-                              child: Text(
-                                widget.memberLabels[id] ?? id,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                            SizedBox(
-                              width: _participantColumnWidth,
-                              child: Center(
-                                child: Checkbox(
-                                  value: _participantIds.contains(id),
-                                  onChanged: !canEdit
-                                      ? null
-                                      : (checked) {
-                                          setState(() {
-                                            if (checked == true) {
-                                              _participantIds.add(id);
-                                            } else {
-                                              _participantIds.remove(id);
-                                            }
-                                          });
-                                        },
-                                ),
-                              ),
-                            ),
-                          ],
+                        controlAffinity: ListTileControlAffinity.leading,
+                        title: Text(
+                          widget.memberLabels[id] ?? id,
+                          overflow: TextOverflow.ellipsis,
                         ),
-                      );
-                    }),
+                        value: _participantIds.contains(id),
+                        onChanged: !_editing
+                            ? null
+                            : (checked) {
+                                setState(() {
+                                  if (checked == true) {
+                                    _participantIds.add(id);
+                                  } else {
+                                    _participantIds.remove(id);
+                                  }
+                                });
+                              },
+                      ),
                   ],
                 ),
               ),
@@ -1731,65 +1673,28 @@ class _AddExpenseSheetState extends ConsumerState<_AddExpenseSheet> {
                         ),
                         child: Column(
                           children: [
-                            Padding(
-                              padding: const EdgeInsets.fromLTRB(12, 10, 12, 8),
-                              child: Row(
-                                children: [
-                                  const Expanded(child: Text('Voyageur')),
-                                  SizedBox(
-                                    width: _participantColumnWidth,
-                                    child: Center(
-                                      child: Tooltip(
-                                        message: 'Partage',
-                                        child: Icon(
-                                          Icons.payments_outlined,
-                                          size: 18,
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .primary,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                            const Divider(height: 1),
-                            ...members.map((id) {
-                              return Padding(
-                                padding: const EdgeInsets.symmetric(
+                            for (final id in members)
+                              CheckboxListTile(
+                                contentPadding: const EdgeInsets.symmetric(
                                   horizontal: 12,
-                                  vertical: 2,
                                 ),
-                                child: Row(
-                                  children: [
-                                    Expanded(
-                                      child: Text(
-                                        labels[id] ?? id,
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                    ),
-                                    SizedBox(
-                                      width: _participantColumnWidth,
-                                      child: Center(
-                                        child: Checkbox(
-                                          value: _participantIds.contains(id),
-                                          onChanged: (checked) {
-                                            setState(() {
-                                              if (checked == true) {
-                                                _participantIds.add(id);
-                                              } else {
-                                                _participantIds.remove(id);
-                                              }
-                                            });
-                                          },
-                                        ),
-                                      ),
-                                    ),
-                                  ],
+                                controlAffinity:
+                                    ListTileControlAffinity.leading,
+                                title: Text(
+                                  labels[id] ?? id,
+                                  overflow: TextOverflow.ellipsis,
                                 ),
-                              );
-                            }),
+                                value: _participantIds.contains(id),
+                                onChanged: (checked) {
+                                  setState(() {
+                                    if (checked == true) {
+                                      _participantIds.add(id);
+                                    } else {
+                                      _participantIds.remove(id);
+                                    }
+                                  });
+                                },
+                              ),
                           ],
                         ),
                       ),

--- a/lib/features/expenses/presentation/trip_expenses_page.dart
+++ b/lib/features/expenses/presentation/trip_expenses_page.dart
@@ -988,6 +988,8 @@ class _ExpenseDetailsPageState extends ConsumerState<_ExpenseDetailsPage> {
   late String? _paidBy;
   late Set<String> _participantIds;
   late DateTime _expenseDate;
+  late ExpenseSplitMode _splitMode;
+  final Map<String, TextEditingController> _shareControllers = {};
   bool _editing = false;
   bool _saving = false;
   bool _deleting = false;
@@ -1022,13 +1024,141 @@ class _ExpenseDetailsPageState extends ConsumerState<_ExpenseDetailsPage> {
       widget.expense.expenseDate.month,
       widget.expense.expenseDate.day,
     );
+    _splitMode = widget.expense.splitMode;
+    if (_splitMode == ExpenseSplitMode.customAmounts) {
+      final n = _participantIds.length;
+      final each = n > 0 ? widget.expense.amount / n : 0.0;
+      for (final id in _participantIds) {
+        final v = widget.expense.participantShares[id] ?? each;
+        _shareControllers[id] = TextEditingController(
+          text: v.toStringAsFixed(2),
+        );
+      }
+    }
   }
 
   @override
   void dispose() {
+    for (final c in _shareControllers.values) {
+      c.dispose();
+    }
+    _shareControllers.clear();
     _titleController.dispose();
     _amountController.dispose();
     super.dispose();
+  }
+
+  double _parsedTotalAmount() {
+    return double.tryParse(
+          _amountController.text.trim().replaceAll(',', '.'),
+        ) ??
+        widget.expense.amount;
+  }
+
+  String _formatShareMoney(double value) {
+    final symbol = _currency == 'USD' ? r'$' : '€';
+    return NumberFormat.currency(
+      locale: 'fr_FR',
+      symbol: symbol,
+      decimalDigits: 2,
+    ).format(value);
+  }
+
+  void _onSplitModeChanged(ExpenseSplitMode mode) {
+    setState(() {
+      _splitMode = mode;
+      if (mode == ExpenseSplitMode.equal) {
+        for (final c in _shareControllers.values) {
+          c.dispose();
+        }
+        _shareControllers.clear();
+      } else {
+        final total = _parsedTotalAmount();
+        final ids = _participantIds.toList();
+        final n = ids.length;
+        final each = n > 0 ? total / n : 0.0;
+        final idSet = ids.toSet();
+        for (final id in ids) {
+          if (!_shareControllers.containsKey(id)) {
+            _shareControllers[id] = TextEditingController(
+              text: each.toStringAsFixed(2),
+            );
+          }
+        }
+        final toRemove =
+            _shareControllers.keys.where((k) => !idSet.contains(k)).toList();
+        for (final k in toRemove) {
+          _shareControllers.remove(k)?.dispose();
+        }
+      }
+    });
+  }
+
+  Map<String, double>? _parseCustomSharesForSave() {
+    final ids = _participantIds.toList();
+    if (ids.isEmpty) return null;
+    final out = <String, double>{};
+    for (final id in ids) {
+      final c = _shareControllers[id];
+      final t = (c?.text ?? '').trim().replaceAll(',', '.');
+      final n = double.tryParse(t);
+      if (n == null || n < 0) return null;
+      out[id] = n;
+    }
+    final sum = out.values.fold<double>(0, (a, b) => a + b);
+    final total = _parsedTotalAmount();
+    if ((sum - total).abs() > 0.02) return null;
+    return out;
+  }
+
+  Widget? _shareAmountTrailing(String memberId) {
+    if (!_participantIds.contains(memberId)) {
+      return Text(
+        '—',
+        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+      );
+    }
+    if (_splitMode == ExpenseSplitMode.equal) {
+      final n = _participantIds.length;
+      final per = n > 0 ? _parsedTotalAmount() / n : 0.0;
+      return Text(
+        _formatShareMoney(per),
+        style: Theme.of(context).textTheme.bodyMedium,
+      );
+    }
+    if (_editing) {
+      final c = _shareControllers[memberId];
+      if (c == null) {
+        return const SizedBox(width: 88);
+      }
+      return SizedBox(
+        width: 100,
+        child: TextField(
+          controller: c,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          inputFormatters: [
+            FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
+          ],
+          textAlign: TextAlign.end,
+          decoration: const InputDecoration(
+            isDense: true,
+            contentPadding: EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+            border: OutlineInputBorder(),
+          ),
+        ),
+      );
+    }
+    final c = _shareControllers[memberId];
+    final parsed = c != null
+        ? double.tryParse(c.text.trim().replaceAll(',', '.'))
+        : null;
+    final v = parsed ?? widget.expense.participantShares[memberId] ?? 0.0;
+    return Text(
+      _formatShareMoney(v),
+      style: Theme.of(context).textTheme.bodyMedium,
+    );
   }
 
   Future<void> _pickExpenseDate() async {
@@ -1140,6 +1270,21 @@ class _ExpenseDetailsPageState extends ConsumerState<_ExpenseDetailsPage> {
       return;
     }
 
+    Map<String, double>? customShares;
+    if (_splitMode == ExpenseSplitMode.customAmounts) {
+      customShares = _parseCustomSharesForSave();
+      if (customShares == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Pour « Montants », chaque part doit être valide et la somme doit égaler le total.',
+            ),
+          ),
+        );
+        return;
+      }
+    }
+
     setState(() => _saving = true);
     try {
       await ref.read(expensesRepositoryProvider).updateExpense(
@@ -1151,6 +1296,8 @@ class _ExpenseDetailsPageState extends ConsumerState<_ExpenseDetailsPage> {
             paidBy: paidBy,
             participantIds: _participantIds.toList(),
             expenseDate: _expenseDate,
+            splitMode: _splitMode,
+            participantShares: customShares,
           );
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -1238,6 +1385,9 @@ class _ExpenseDetailsPageState extends ConsumerState<_ExpenseDetailsPage> {
                         decimal: true,
                       ),
                       readOnly: !_editing,
+                      onChanged: !_editing
+                          ? null
+                          : (_) => setState(() {}),
                       inputFormatters: [
                         FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
                       ],
@@ -1327,9 +1477,46 @@ class _ExpenseDetailsPageState extends ConsumerState<_ExpenseDetailsPage> {
                 ],
               ),
               const SizedBox(height: 16),
-              Text(
-                'Partage du montant',
-                style: Theme.of(context).textTheme.titleSmall,
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Partage du montant',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                  ),
+                  if (_editing)
+                    DropdownButton<ExpenseSplitMode>(
+                      value: _splitMode,
+                      underline: const SizedBox.shrink(),
+                      alignment: AlignmentDirectional.centerEnd,
+                      items: const [
+                        DropdownMenuItem(
+                          value: ExpenseSplitMode.equal,
+                          child: Text('Équitablement'),
+                        ),
+                        DropdownMenuItem(
+                          value: ExpenseSplitMode.customAmounts,
+                          child: Text('Montants'),
+                        ),
+                      ],
+                      onChanged: (mode) {
+                        if (mode != null) _onSplitModeChanged(mode);
+                      },
+                    )
+                  else
+                    Text(
+                      _splitMode == ExpenseSplitMode.equal
+                          ? 'Équitablement'
+                          : 'Montants',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurfaceVariant,
+                          ),
+                    ),
+                ],
               ),
               const SizedBox(height: 8),
               Container(
@@ -1351,6 +1538,7 @@ class _ExpenseDetailsPageState extends ConsumerState<_ExpenseDetailsPage> {
                           widget.memberLabels[id] ?? id,
                           overflow: TextOverflow.ellipsis,
                         ),
+                        secondary: _shareAmountTrailing(id),
                         value: _participantIds.contains(id),
                         onChanged: !_editing
                             ? null
@@ -1358,8 +1546,25 @@ class _ExpenseDetailsPageState extends ConsumerState<_ExpenseDetailsPage> {
                                 setState(() {
                                   if (checked == true) {
                                     _participantIds.add(id);
+                                    if (_splitMode ==
+                                        ExpenseSplitMode.customAmounts) {
+                                      final total = _parsedTotalAmount();
+                                      final n = _participantIds.length;
+                                      final each =
+                                          n > 0 ? total / n : 0.0;
+                                      _shareControllers[id] =
+                                          TextEditingController(
+                                        text: each.toStringAsFixed(2),
+                                      );
+                                    }
                                   } else {
                                     _participantIds.remove(id);
+                                    if (_splitMode ==
+                                        ExpenseSplitMode.customAmounts) {
+                                      _shareControllers
+                                          .remove(id)
+                                          ?.dispose();
+                                    }
                                   }
                                 });
                               },

--- a/lib/features/trips/presentation/trip_edit_request_provider.dart
+++ b/lib/features/trips/presentation/trip_edit_request_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// When [state] becomes `true`, [TripOverviewPage] opens trip metadata editing once.
+///
+/// The overview resets this notifier after handling (e.g. shell AppBar "edit trip").
+final tripEditRequestedProvider =
+    NotifierProvider.autoDispose.family<TripEditRequested, bool, String>(
+  TripEditRequested.new,
+);
+
+class TripEditRequested extends Notifier<bool> {
+  /// [tripId] scopes the family instance; editing logic uses the same id from UI.
+  TripEditRequested(String _);
+
+  @override
+  bool build() => false;
+
+  void request() => state = true;
+
+  void clear() => state = false;
+}

--- a/lib/features/trips/presentation/trip_overview_page.dart
+++ b/lib/features/trips/presentation/trip_overview_page.dart
@@ -10,6 +10,7 @@ import 'package:planzers/features/auth/data/user_display_label.dart';
 import 'package:planzers/features/trips/data/trip.dart';
 import 'package:planzers/features/trips/data/trips_repository.dart';
 import 'package:planzers/features/trips/presentation/trip_date_format.dart';
+import 'package:planzers/features/trips/presentation/trip_edit_request_provider.dart';
 import 'package:planzers/features/trips/presentation/trip_scope.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -275,6 +276,16 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
   Widget build(BuildContext context) {
     final myUid = FirebaseAuth.instance.currentUser?.uid;
     final canEdit = (myUid != null && myUid == _trip.ownerId);
+    ref.listen<bool>(tripEditRequestedProvider(_trip.id), (previous, next) {
+      if (next != true || !canEdit) return;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        ref.read(tripEditRequestedProvider(_trip.id).notifier).clear();
+        if (!_isEditing) {
+          _startEditing();
+        }
+      });
+    });
     final tripDocStream = FirebaseFirestore.instance
         .collection('trips')
         .doc(_trip.id)
@@ -348,11 +359,6 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
                         onPressed:
                             _inviteClipboardBusy ? null : _copyInviteCode,
                         icon: const Icon(Icons.vpn_key_outlined),
-                      ),
-                      IconButton(
-                        tooltip: 'Modifier',
-                        onPressed: _startEditing,
-                        icon: const Icon(Icons.edit_outlined),
                       ),
                     ],
                   ],

--- a/lib/features/trips/presentation/trip_shell_page.dart
+++ b/lib/features/trips/presentation/trip_shell_page.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:planzers/features/account/presentation/account_menu_button.dart';
 import 'package:planzers/features/trips/data/trip.dart';
 import 'package:planzers/features/trips/data/trips_repository.dart';
+import 'package:planzers/features/trips/presentation/trip_edit_request_provider.dart';
 import 'package:planzers/features/trips/presentation/trip_scope.dart';
 
 /// Backfill [Trip.memberPublicLabels] for the current user (e.g. voyages créés
@@ -98,6 +99,8 @@ class TripShellPage extends ConsumerWidget {
         }
 
         final titleForAppBar = trip.title.isEmpty ? 'Voyage' : trip.title;
+        final myUid = FirebaseAuth.instance.currentUser?.uid;
+        final canEditTrip = myUid != null && myUid == trip.ownerId;
 
         _scheduleTripMemberPublicLabelHealIfNeeded(ref, trip);
 
@@ -117,8 +120,30 @@ class TripShellPage extends ConsumerWidget {
                     onPressed: () => context.go('/trips'),
                     tooltip: 'Mes voyages',
                   ),
-                  actions: const [
-                    AccountMenuButton(),
+                  actions: [
+                    if (canEditTrip)
+                      IconButton(
+                        icon: const Icon(Icons.edit_outlined),
+                        tooltip: 'Modifier le voyage',
+                        onPressed: () {
+                          void requestEdit() {
+                            ref
+                                .read(
+                                  tripEditRequestedProvider(trip.id).notifier,
+                                )
+                                .request();
+                          }
+
+                          if (navigationShell.currentIndex != 0) {
+                            navigationShell.goBranch(0);
+                            WidgetsBinding.instance
+                                .addPostFrameCallback((_) => requestEdit());
+                          } else {
+                            requestEdit();
+                          }
+                        },
+                      ),
+                    const AccountMenuButton(),
                   ],
                 ),
                 body: Row(

--- a/test/expense_settlement_test.dart
+++ b/test/expense_settlement_test.dart
@@ -9,6 +9,8 @@ TripExpense _e({
   String currency = 'EUR',
   String groupId = 'g1',
   String id = 'x',
+  ExpenseSplitMode splitMode = ExpenseSplitMode.equal,
+  Map<String, double>? participantShares,
 }) {
   return TripExpense(
     id: id,
@@ -21,6 +23,8 @@ TripExpense _e({
     category: 'other',
     createdAt: DateTime(2026, 1, 1),
     expenseDate: DateTime(2026, 1, 1),
+    splitMode: splitMode,
+    participantShares: participantShares,
   );
 }
 
@@ -87,6 +91,21 @@ void main() {
     final settlement = computeViewerSettlement(expenses, null);
     expect(settlement.suggestedTransfers, hasLength(1));
     expect(settlement.suggestedTransfers.single.fromUserId, 'b');
+  });
+
+  test('custom split: balances follow participantShares', () {
+    final expenses = [
+      _e(
+        paidBy: 'a',
+        participants: ['a', 'b'],
+        amount: 100,
+        splitMode: ExpenseSplitMode.customAmounts,
+        participantShares: {'a': 30, 'b': 70},
+      ),
+    ];
+    final bal = computeBalances(expenses)['EUR']!;
+    expect(bal['a'], closeTo(70, 0.01));
+    expect(bal['b'], closeTo(-70, 0.01));
   });
 
   test('per-post scope: two groups do not merge balances', () {


### PR DESCRIPTION
This pull request introduces support for custom expense splitting in the trip expenses feature, allowing each participant to have a specific share of an expense rather than always splitting equally. It also refactors the trip editing UI flow to move the edit button from the overview page to the shell app bar and introduces a notifier-based mechanism for handling edit requests. Additionally, it updates project guidelines regarding UI copy and improves test coverage for the new split logic.

**Expense Splitting Enhancements:**

* Added the `ExpenseSplitMode` enum and new fields (`splitMode`, `participantShares`) to the `TripExpense` model, enabling both equal and custom amount splits among participants. Serialization and deserialization logic was updated accordingly. [[1]](diffhunk://#diff-4169aa39e922b3f5dbec757eb559b83f4e3919fcd211857ff6a8cd781a34cf70R3-R11) [[2]](diffhunk://#diff-4169aa39e922b3f5dbec757eb559b83f4e3919fcd211857ff6a8cd781a34cf70L17-R28) [[3]](diffhunk://#diff-4169aa39e922b3f5dbec757eb559b83f4e3919fcd211857ff6a8cd781a34cf70R44-R48) [[4]](diffhunk://#diff-4169aa39e922b3f5dbec757eb559b83f4e3919fcd211857ff6a8cd781a34cf70R89-R90) [[5]](diffhunk://#diff-4169aa39e922b3f5dbec757eb559b83f4e3919fcd211857ff6a8cd781a34cf70L81-R99) [[6]](diffhunk://#diff-4169aa39e922b3f5dbec757eb559b83f4e3919fcd211857ff6a8cd781a34cf70R112-R147) [[7]](diffhunk://#diff-08afc8a097bac8bf145dbdb18a7cfeff06041ff43c64e669db89081749518d91R239-R240) [[8]](diffhunk://#diff-08afc8a097bac8bf145dbdb18a7cfeff06041ff43c64e669db89081749518d91R262-R263)
* Updated `ExpensesRepository` to handle custom split modes when creating and updating expenses, ensuring correct storage and updates of participant shares. [[1]](diffhunk://#diff-08afc8a097bac8bf145dbdb18a7cfeff06041ff43c64e669db89081749518d91L298-R302) [[2]](diffhunk://#diff-08afc8a097bac8bf145dbdb18a7cfeff06041ff43c64e669db89081749518d91L310-R327)
* Enhanced the balance computation logic in `expense_settlement.dart` to support custom participant shares, with fallback to equal split if data is missing or inconsistent. [[1]](diffhunk://#diff-213e6c25b21813b42ad0bc680a3eb7df04fe2e5c3287b53fc2bbe905720a698dL66-R67) [[2]](diffhunk://#diff-213e6c25b21813b42ad0bc680a3eb7df04fe2e5c3287b53fc2bbe905720a698dL88-R133)

**Trip Editing UX Improvements:**

* Moved the trip edit button from the overview page to the shell app bar, displaying it only for trip owners. [[1]](diffhunk://#diff-ccd4badd91ea29233b7cc48ae069d093de08e45b94a77838d699f225dbb0d715L352-L356) [[2]](diffhunk://#diff-0fc46f86e444989081ab80a3bd0157579d43ab24e61fdb0a39eebb34a637e664R102-R103) [[3]](diffhunk://#diff-0fc46f86e444989081ab80a3bd0157579d43ab24e61fdb0a39eebb34a637e664L120-R146)
* Introduced `tripEditRequestedProvider` (a Riverpod notifier) to coordinate edit requests across navigation branches, ensuring the edit dialog opens in the correct context. [[1]](diffhunk://#diff-b401dd4cc0b7909b8390727c8e084666c33d7959d2a3fbcebe8c99fd4c75c09aR1-R21) [[2]](diffhunk://#diff-ccd4badd91ea29233b7cc48ae069d093de08e45b94a77838d699f225dbb0d715R13) [[3]](diffhunk://#diff-ccd4badd91ea29233b7cc48ae069d093de08e45b94a77838d699f225dbb0d715R279-R288) [[4]](diffhunk://#diff-0fc46f86e444989081ab80a3bd0157579d43ab24e61fdb0a39eebb34a637e664R8)

**Testing and Guidelines:**

* Added and updated tests to verify custom split logic in balances and settlement calculations. [[1]](diffhunk://#diff-53ddd4da4724c3098a5c4016732f7928f97411f7899bb9e70dd781226669668cR12-R13) [[2]](diffhunk://#diff-53ddd4da4724c3098a5c4016732f7928f97411f7899bb9e70dd781226669668cR26-R27) [[3]](diffhunk://#diff-53ddd4da4724c3098a5c4016732f7928f97411f7899bb9e70dd781226669668cR96-R110)
* Updated project guidelines to clarify that UI copy for agents should avoid extra explanations unless explicitly requested. [[1]](diffhunk://#diff-22e674f3d1da91695fbafd4d2c81f91246cfabab3d16dcf6492e6024797b4da5R14) [[2]](diffhunk://#diff-2bf2026cc5fcf6c7122a6ca98ece7fb7a3bdb43b70294626a4c5cffb785cf7e1R19)