### PR TITLE
Work/feat 24

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,5 +1,5 @@
 const admin = require('firebase-admin');
-const { onDocumentUpdated } = require('firebase-functions/v2/firestore');
+const { onDocumentUpdated, onDocumentWritten } = require('firebase-functions/v2/firestore');
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
 const cheerio = require('cheerio');
 
@@ -95,6 +95,91 @@ function parsePreviewFromHtml(pageUrl, html) {
   };
 }
 
+/**
+ * Writes `linkPreview` on [docRef] from [afterUrlRaw], or clears it when empty.
+ * Used for trip documents and activity subdocuments (same field names).
+ * @param {FirebaseFirestore.DocumentReference} docRef
+ * @param {string} afterUrlRaw
+ */
+async function applyLinkPreview(docRef, afterUrlRaw) {
+  const FieldValue = admin.firestore.FieldValue;
+  const afterUrl = normalizeString(afterUrlRaw);
+  if (!afterUrl) {
+    await docRef.set(
+      {
+        linkPreview: FieldValue.delete(),
+      },
+      { merge: true }
+    );
+    return;
+  }
+
+  const parsed = safeUrl(afterUrl);
+  if (!parsed) {
+    await docRef.set(
+      {
+        linkPreview: {
+          status: 'error',
+          url: afterUrl,
+          error: 'invalid_url',
+          fetchedAt: FieldValue.serverTimestamp(),
+        },
+      },
+      { merge: true }
+    );
+    return;
+  }
+
+  await docRef.set(
+    {
+      linkPreview: {
+        status: 'loading',
+        url: parsed.toString(),
+        fetchedAt: FieldValue.serverTimestamp(),
+      },
+    },
+    { merge: true }
+  );
+
+  try {
+    const html = await fetchHtml(parsed);
+    const preview = parsePreviewFromHtml(parsed, html);
+
+    const hasSomething =
+      preview.title ||
+      preview.description ||
+      preview.imageUrl ||
+      preview.siteName;
+
+    await docRef.set(
+      {
+        linkPreview: {
+          status: hasSomething ? 'ok' : 'empty',
+          url: parsed.toString(),
+          title: preview.title,
+          description: preview.description,
+          siteName: preview.siteName,
+          imageUrl: preview.imageUrl,
+          fetchedAt: FieldValue.serverTimestamp(),
+        },
+      },
+      { merge: true }
+    );
+  } catch (e) {
+    await docRef.set(
+      {
+        linkPreview: {
+          status: 'error',
+          url: parsed.toString(),
+          error: String(e),
+          fetchedAt: FieldValue.serverTimestamp(),
+        },
+      },
+      { merge: true }
+    );
+  }
+}
+
 /** @param {FirebaseFirestore.DocumentData} data */
 function memberIdsAsSet(data) {
   const raw = data.memberIds;
@@ -186,7 +271,7 @@ exports.backfillNewTripMemberInExpenses = onDocumentUpdated(
   }
 );
 
-exports.generateTripLinkPreview = onDocumentUpdated(
+exports.generateTripLinkPreview = onDocumentWritten(
   {
     document: 'trips/{tripId}',
     region: 'europe-west1',
@@ -194,89 +279,39 @@ exports.generateTripLinkPreview = onDocumentUpdated(
     memory: '256MiB',
   },
   async (event) => {
-    const before = event.data.before.data() || {};
+    if (!event.data.after.exists) return;
+    const before = event.data.before.exists
+      ? event.data.before.data() || {}
+      : {};
     const after = event.data.after.data() || {};
 
     const beforeUrl = normalizeString(before.linkUrl);
     const afterUrl = normalizeString(after.linkUrl);
-
-    // Avoid loops: only run when linkUrl actually changes.
     if (beforeUrl === afterUrl) return;
 
-    const tripRef = event.data.after.ref;
+    await applyLinkPreview(event.data.after.ref, afterUrl);
+  }
+);
 
-    if (!afterUrl) {
-      await tripRef.set(
-        {
-          linkPreview: admin.firestore.FieldValue.delete(),
-        },
-        { merge: true }
-      );
-      return;
-    }
+exports.generateActivityLinkPreview = onDocumentWritten(
+  {
+    document: 'trips/{tripId}/activities/{activityId}',
+    region: 'europe-west1',
+    timeoutSeconds: 30,
+    memory: '256MiB',
+  },
+  async (event) => {
+    if (!event.data.after.exists) return;
+    const before = event.data.before.exists
+      ? event.data.before.data() || {}
+      : {};
+    const after = event.data.after.data() || {};
 
-    const parsed = safeUrl(afterUrl);
-    if (!parsed) {
-      await tripRef.set(
-        {
-          linkPreview: {
-            status: 'error',
-            url: afterUrl,
-            error: 'invalid_url',
-            fetchedAt: admin.firestore.FieldValue.serverTimestamp(),
-          },
-        },
-        { merge: true }
-      );
-      return;
-    }
+    const beforeUrl = normalizeString(before.linkUrl);
+    const afterUrl = normalizeString(after.linkUrl);
+    if (beforeUrl === afterUrl) return;
 
-    // Mark as loading (UI can show spinner).
-    await tripRef.set(
-      {
-        linkPreview: {
-          status: 'loading',
-          url: parsed.toString(),
-          fetchedAt: admin.firestore.FieldValue.serverTimestamp(),
-        },
-      },
-      { merge: true }
-    );
-
-    try {
-      const html = await fetchHtml(parsed);
-      const preview = parsePreviewFromHtml(parsed, html);
-
-      const hasSomething =
-        preview.title || preview.description || preview.imageUrl || preview.siteName;
-
-      await tripRef.set(
-        {
-          linkPreview: {
-            status: hasSomething ? 'ok' : 'empty',
-            url: parsed.toString(),
-            title: preview.title,
-            description: preview.description,
-            siteName: preview.siteName,
-            imageUrl: preview.imageUrl,
-            fetchedAt: admin.firestore.FieldValue.serverTimestamp(),
-          },
-        },
-        { merge: true }
-      );
-    } catch (e) {
-      await tripRef.set(
-        {
-          linkPreview: {
-            status: 'error',
-            url: parsed.toString(),
-            error: String(e),
-            fetchedAt: admin.firestore.FieldValue.serverTimestamp(),
-          },
-        },
-        { merge: true }
-      );
-    }
+    await applyLinkPreview(event.data.after.ref, afterUrl);
   }
 );
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,12 +1,51 @@
 const admin = require('firebase-admin');
 const { onDocumentUpdated, onDocumentWritten } = require('firebase-functions/v2/firestore');
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
+const { defineSecret } = require('firebase-functions/params');
 const cheerio = require('cheerio');
 
 admin.initializeApp();
 
+const googleMapsApiKey = defineSecret('GOOGLE_MAPS_API_KEY');
+
 function normalizeString(v) {
   return (typeof v === 'string' ? v : '').trim();
+}
+
+/**
+ * @param {string} originAddress
+ * @param {string} destAddress
+ * @param {string} apiKey
+ * @returns {Promise<{ distanceMeters: number, durationSeconds: number, distanceText: string, durationText: string } | { elementStatus: string }>}
+ */
+async function fetchDrivingMatrix(originAddress, destAddress, apiKey) {
+  const params = new URLSearchParams({
+    origins: originAddress,
+    destinations: destAddress,
+    mode: 'driving',
+    units: 'metric',
+    key: apiKey,
+  });
+  const url = `https://maps.googleapis.com/maps/api/distancematrix/json?${params.toString()}`;
+  const res = await fetch(url);
+  const data = await res.json();
+  if (data.status !== 'OK') {
+    const msg = [data.status, data.error_message].filter(Boolean).join(' ');
+    throw new Error(msg || 'Distance Matrix request failed');
+  }
+  const el = data.rows?.[0]?.elements?.[0];
+  if (!el) {
+    throw new Error('Distance Matrix empty rows');
+  }
+  if (el.status !== 'OK') {
+    return { elementStatus: el.status };
+  }
+  return {
+    distanceMeters: el.distance.value,
+    durationSeconds: el.duration.value,
+    distanceText: el.distance.text,
+    durationText: el.duration.text,
+  };
 }
 
 function safeUrl(v) {
@@ -312,6 +351,110 @@ exports.generateActivityLinkPreview = onDocumentWritten(
     if (beforeUrl === afterUrl) return;
 
     await applyLinkPreview(event.data.after.ref, afterUrl);
+  }
+);
+
+exports.computeActivityDrivingRouteFromTrip = onDocumentWritten(
+  {
+    document: 'trips/{tripId}/activities/{activityId}',
+    region: 'europe-west1',
+    secrets: [googleMapsApiKey],
+    timeoutSeconds: 60,
+    memory: '256MiB',
+  },
+  async (event) => {
+    const FieldValue = admin.firestore.FieldValue;
+    if (!event.data.after.exists) {
+      return;
+    }
+
+    const before = event.data.before.exists
+      ? event.data.before.data() || {}
+      : {};
+    const after = event.data.after.data() || {};
+    const beforeAddr = normalizeString(before.address);
+    const afterAddr = normalizeString(after.address);
+
+    if (event.data.before.exists && beforeAddr === afterAddr) {
+      return;
+    }
+
+    const docRef = event.data.after.ref;
+    const tripId = event.params.tripId;
+
+    if (!afterAddr) {
+      await docRef.set(
+        {
+          tripDrivingRoute: FieldValue.delete(),
+        },
+        { merge: true }
+      );
+      return;
+    }
+
+    const tripSnap = await admin
+      .firestore()
+      .collection('trips')
+      .doc(tripId)
+      .get();
+    const tripData = tripSnap.data() || {};
+    const tripAddress = normalizeString(tripData.address);
+
+    if (!tripAddress) {
+      await docRef.set(
+        {
+          tripDrivingRoute: {
+            status: 'missing_trip_address',
+            calculatedAt: FieldValue.serverTimestamp(),
+          },
+        },
+        { merge: true }
+      );
+      return;
+    }
+
+    const apiKey = googleMapsApiKey.value();
+    try {
+      const result = await fetchDrivingMatrix(tripAddress, afterAddr, apiKey);
+      if (result.elementStatus) {
+        await docRef.set(
+          {
+            tripDrivingRoute: {
+              status: 'no_result',
+              detail: result.elementStatus,
+              calculatedAt: FieldValue.serverTimestamp(),
+            },
+          },
+          { merge: true }
+        );
+        return;
+      }
+
+      await docRef.set(
+        {
+          tripDrivingRoute: {
+            status: 'ok',
+            distanceMeters: result.distanceMeters,
+            durationSeconds: result.durationSeconds,
+            distanceText: result.distanceText,
+            durationText: result.durationText,
+            calculatedAt: FieldValue.serverTimestamp(),
+          },
+        },
+        { merge: true }
+      );
+    } catch (e) {
+      await docRef.set(
+        {
+          tripDrivingRoute: {
+            status: 'error',
+            errorMessage: String(e),
+            calculatedAt: FieldValue.serverTimestamp(),
+          },
+        },
+        { merge: true }
+      );
+    }
   }
 );
 

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -3,6 +3,7 @@ import 'package:planzers/features/account/presentation/account_page.dart';
 import 'package:planzers/features/auth/auth_gate.dart';
 import 'package:planzers/features/auth/sign_in_page.dart';
 import 'package:planzers/features/trips/presentation/invite_join_page.dart';
+import 'package:planzers/features/activities/presentation/trip_activities_page.dart';
 import 'package:planzers/features/expenses/presentation/trip_expenses_page.dart';
 import 'package:planzers/features/trips/presentation/trip_overview_page.dart';
 import 'package:planzers/features/trips/presentation/trip_shell_page.dart';

--- a/lib/features/activities/data/activities_repository.dart
+++ b/lib/features/activities/data/activities_repository.dart
@@ -47,7 +47,7 @@ class ActivitiesRepository {
     required String label,
     required TripActivityCategory category,
     required String linkUrl,
-    required String itinerary,
+    required String address,
     required String freeComments,
   }) async {
     final user = auth.currentUser;
@@ -69,10 +69,40 @@ class ActivitiesRepository {
       'label': cleanLabel,
       'category': category.firestoreValue,
       'linkUrl': linkUrl.trim(),
-      'itinerary': itinerary.trim(),
+      'address': address.trim(),
       'freeComments': freeComments.trim(),
+      'done': false,
       'createdBy': user.uid,
       'createdAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  /// Any signed-in user may toggle (trip membership enforced by Firestore rules).
+  Future<void> setActivityDone({
+    required String tripId,
+    required String activityId,
+    required bool done,
+  }) async {
+    final user = auth.currentUser;
+    if (user == null) {
+      throw StateError('Utilisateur non connecte');
+    }
+
+    final cleanTripId = tripId.trim();
+    final cleanActivityId = activityId.trim();
+    if (cleanTripId.isEmpty || cleanActivityId.isEmpty) {
+      throw StateError('Activite invalide');
+    }
+
+    final docRef = _activitiesCol(cleanTripId).doc(cleanActivityId);
+    final snap = await docRef.get();
+    if (!snap.exists) {
+      throw StateError('Activite introuvable');
+    }
+
+    await docRef.update({
+      'done': done,
+      'updatedAt': FieldValue.serverTimestamp(),
     });
   }
 
@@ -82,7 +112,7 @@ class ActivitiesRepository {
     required String label,
     required TripActivityCategory category,
     required String linkUrl,
-    required String itinerary,
+    required String address,
     required String freeComments,
   }) async {
     final user = auth.currentUser;
@@ -115,8 +145,9 @@ class ActivitiesRepository {
       'label': cleanLabel,
       'category': category.firestoreValue,
       'linkUrl': linkUrl.trim(),
-      'itinerary': itinerary.trim(),
+      'address': address.trim(),
       'freeComments': freeComments.trim(),
+      'itinerary': FieldValue.delete(),
       'updatedAt': FieldValue.serverTimestamp(),
     });
   }

--- a/lib/features/activities/data/activities_repository.dart
+++ b/lib/features/activities/data/activities_repository.dart
@@ -1,0 +1,151 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:planzers/features/activities/data/trip_activity.dart';
+
+final activitiesRepositoryProvider = Provider<ActivitiesRepository>((ref) {
+  return ActivitiesRepository(
+    firestore: FirebaseFirestore.instance,
+    auth: FirebaseAuth.instance,
+  );
+});
+
+/// Live activities for a trip, newest first.
+final tripActivitiesStreamProvider =
+    StreamProvider.autoDispose.family<List<TripActivity>, String>(
+        (ref, tripId) {
+  return ref.watch(activitiesRepositoryProvider).watchTripActivities(tripId);
+});
+
+class ActivitiesRepository {
+  ActivitiesRepository({
+    required this.firestore,
+    required this.auth,
+  });
+
+  final FirebaseFirestore firestore;
+  final FirebaseAuth auth;
+
+  CollectionReference<Map<String, dynamic>> _activitiesCol(String tripId) {
+    return firestore.collection('trips').doc(tripId).collection('activities');
+  }
+
+  Stream<List<TripActivity>> watchTripActivities(String tripId) {
+    final cleanId = tripId.trim();
+    if (cleanId.isEmpty) {
+      return Stream.value(const <TripActivity>[]);
+    }
+
+    return _activitiesCol(cleanId)
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((snap) => snap.docs.map(TripActivity.fromDoc).toList());
+  }
+
+  Future<void> addActivity({
+    required String tripId,
+    required String label,
+    required TripActivityCategory category,
+    required String linkUrl,
+    required String itinerary,
+    required String freeComments,
+  }) async {
+    final user = auth.currentUser;
+    if (user == null) {
+      throw StateError('Utilisateur non connecte');
+    }
+
+    final cleanTripId = tripId.trim();
+    if (cleanTripId.isEmpty) {
+      throw StateError('Voyage invalide');
+    }
+
+    final cleanLabel = label.trim();
+    if (cleanLabel.isEmpty) {
+      throw StateError('Libelle obligatoire');
+    }
+
+    await _activitiesCol(cleanTripId).add({
+      'label': cleanLabel,
+      'category': category.firestoreValue,
+      'linkUrl': linkUrl.trim(),
+      'itinerary': itinerary.trim(),
+      'freeComments': freeComments.trim(),
+      'createdBy': user.uid,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  Future<void> updateActivity({
+    required String tripId,
+    required String activityId,
+    required String label,
+    required TripActivityCategory category,
+    required String linkUrl,
+    required String itinerary,
+    required String freeComments,
+  }) async {
+    final user = auth.currentUser;
+    if (user == null) {
+      throw StateError('Utilisateur non connecte');
+    }
+
+    final cleanTripId = tripId.trim();
+    final cleanActivityId = activityId.trim();
+    if (cleanTripId.isEmpty || cleanActivityId.isEmpty) {
+      throw StateError('Activite invalide');
+    }
+
+    final cleanLabel = label.trim();
+    if (cleanLabel.isEmpty) {
+      throw StateError('Libelle obligatoire');
+    }
+
+    final docRef = _activitiesCol(cleanTripId).doc(cleanActivityId);
+    final snap = await docRef.get();
+    if (!snap.exists) {
+      throw StateError('Activite introuvable');
+    }
+    final createdBy = (snap.data()?['createdBy'] as String?)?.trim() ?? '';
+    if (createdBy.isEmpty || createdBy != user.uid) {
+      throw StateError('Modification reservee a l auteur de la proposition');
+    }
+
+    await docRef.update({
+      'label': cleanLabel,
+      'category': category.firestoreValue,
+      'linkUrl': linkUrl.trim(),
+      'itinerary': itinerary.trim(),
+      'freeComments': freeComments.trim(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
+  Future<void> deleteActivity({
+    required String tripId,
+    required String activityId,
+  }) async {
+    final user = auth.currentUser;
+    if (user == null) {
+      throw StateError('Utilisateur non connecte');
+    }
+
+    final cleanTripId = tripId.trim();
+    final cleanActivityId = activityId.trim();
+    if (cleanTripId.isEmpty || cleanActivityId.isEmpty) {
+      throw StateError('Activite invalide');
+    }
+
+    final docRef = _activitiesCol(cleanTripId).doc(cleanActivityId);
+    final snap = await docRef.get();
+    if (!snap.exists) {
+      throw StateError('Activite introuvable');
+    }
+    final createdBy = (snap.data()?['createdBy'] as String?)?.trim() ?? '';
+    if (createdBy.isEmpty || createdBy != user.uid) {
+      throw StateError('Suppression reservee a l auteur de la proposition');
+    }
+
+    await docRef.delete();
+  }
+}

--- a/lib/features/activities/data/activity_trip_driving_route.dart
+++ b/lib/features/activities/data/activity_trip_driving_route.dart
@@ -1,0 +1,50 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Driving route from the trip vacation address to the activity address,
+/// filled by Cloud Function (`tripDrivingRoute` on the activity document).
+class ActivityTripDrivingRoute {
+  const ActivityTripDrivingRoute({
+    required this.status,
+    this.distanceMeters,
+    this.durationSeconds,
+    this.distanceText,
+    this.durationText,
+    this.detail,
+    this.errorMessage,
+    this.calculatedAt,
+  });
+
+  final String status;
+  final int? distanceMeters;
+  final int? durationSeconds;
+  final String? distanceText;
+  final String? durationText;
+  final String? detail;
+  final String? errorMessage;
+  final DateTime? calculatedAt;
+
+  static ActivityTripDrivingRoute? fromFirestore(dynamic raw) {
+    if (raw is! Map) return null;
+    final m = Map<String, dynamic>.from(raw);
+    final status = (m['status'] as String?)?.trim() ?? '';
+    if (status.isEmpty) return null;
+
+    final dm = m['distanceMeters'];
+    final ds = m['durationSeconds'];
+    final calculatedRaw = m['calculatedAt'];
+
+    return ActivityTripDrivingRoute(
+      status: status,
+      distanceMeters: dm is num ? dm.toInt() : null,
+      durationSeconds: ds is num ? ds.toInt() : null,
+      distanceText: (m['distanceText'] as String?)?.trim(),
+      durationText: (m['durationText'] as String?)?.trim(),
+      detail: (m['detail'] as String?)?.trim(),
+      errorMessage: (m['errorMessage'] as String?)?.trim(),
+      calculatedAt: switch (calculatedRaw) {
+        Timestamp ts => ts.toDate(),
+        _ => null,
+      },
+    );
+  }
+}

--- a/lib/features/activities/data/trip_activity.dart
+++ b/lib/features/activities/data/trip_activity.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:planzers/features/activities/data/activity_trip_driving_route.dart';
 
 /// Proposed outing / activity for a trip
 /// (`trips/{tripId}/activities/{activityId}`).
@@ -8,24 +9,34 @@ class TripActivity {
     required this.label,
     required this.category,
     required this.linkUrl,
-    required this.itinerary,
+    required this.address,
     required this.freeComments,
     required this.createdBy,
     required this.createdAt,
+    this.done = false,
     this.linkPreview = const {},
+    this.tripDrivingRoute,
   });
 
   final String id;
   final String label;
   final TripActivityCategory category;
   final String linkUrl;
-  final String itinerary;
+
+  /// Place address for driving directions from the trip base address (optional).
+  final String address;
   final String freeComments;
   final String createdBy;
   final DateTime createdAt;
 
+  /// Whether participants consider this outing done.
+  final bool done;
+
   /// Same shape as trip `linkPreview` (filled by Cloud Function).
   final Map<String, dynamic> linkPreview;
+
+  /// Driving distance/duration from trip `address` (Cloud Function).
+  final ActivityTripDrivingRoute? tripDrivingRoute;
 
   static Map<String, dynamic> _previewFromFirestore(dynamic raw) {
     if (raw is! Map) return const {};
@@ -41,16 +52,26 @@ class TripActivity {
       _ => DateTime.now(),
     };
 
+    final doneRaw = data['done'];
+    final done = doneRaw is bool
+        ? doneRaw
+        : doneRaw is String
+            ? doneRaw.toLowerCase() == 'true'
+            : false;
+
     return TripActivity(
       id: doc.id,
       label: (data['label'] as String?) ?? '',
       category: TripActivityCategory.fromFirestore(data['category']),
       linkUrl: (data['linkUrl'] as String?) ?? '',
-      itinerary: (data['itinerary'] as String?) ?? '',
+      address: (data['address'] as String?) ?? '',
       freeComments: (data['freeComments'] as String?) ?? '',
       createdBy: (data['createdBy'] as String?) ?? '',
       createdAt: createdAt,
+      done: done,
       linkPreview: _previewFromFirestore(data['linkPreview']),
+      tripDrivingRoute:
+          ActivityTripDrivingRoute.fromFirestore(data['tripDrivingRoute']),
     );
   }
 }

--- a/lib/features/activities/data/trip_activity.dart
+++ b/lib/features/activities/data/trip_activity.dart
@@ -1,0 +1,79 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Proposed outing / activity for a trip
+/// (`trips/{tripId}/activities/{activityId}`).
+class TripActivity {
+  TripActivity({
+    required this.id,
+    required this.label,
+    required this.category,
+    required this.linkUrl,
+    required this.itinerary,
+    required this.freeComments,
+    required this.createdBy,
+    required this.createdAt,
+    this.linkPreview = const {},
+  });
+
+  final String id;
+  final String label;
+  final TripActivityCategory category;
+  final String linkUrl;
+  final String itinerary;
+  final String freeComments;
+  final String createdBy;
+  final DateTime createdAt;
+
+  /// Same shape as trip `linkPreview` (filled by Cloud Function).
+  final Map<String, dynamic> linkPreview;
+
+  static Map<String, dynamic> _previewFromFirestore(dynamic raw) {
+    if (raw is! Map) return const {};
+    return Map<String, dynamic>.from(raw);
+  }
+
+  factory TripActivity.fromDoc(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data() ?? const <String, dynamic>{};
+    final createdAtRaw = data['createdAt'];
+    final createdAt = switch (createdAtRaw) {
+      Timestamp ts => ts.toDate(),
+      String s => DateTime.tryParse(s) ?? DateTime.now(),
+      _ => DateTime.now(),
+    };
+
+    return TripActivity(
+      id: doc.id,
+      label: (data['label'] as String?) ?? '',
+      category: TripActivityCategory.fromFirestore(data['category']),
+      linkUrl: (data['linkUrl'] as String?) ?? '',
+      itinerary: (data['itinerary'] as String?) ?? '',
+      freeComments: (data['freeComments'] as String?) ?? '',
+      createdBy: (data['createdBy'] as String?) ?? '',
+      createdAt: createdAt,
+      linkPreview: _previewFromFirestore(data['linkPreview']),
+    );
+  }
+}
+
+enum TripActivityCategory {
+  sport,
+  shopping,
+  visit,
+  restaurant;
+
+  static TripActivityCategory fromFirestore(dynamic raw) {
+    final s = (raw is String ? raw : raw?.toString() ?? '').trim();
+    for (final e in TripActivityCategory.values) {
+      if (e.firestoreValue == s) return e;
+    }
+    return TripActivityCategory.visit;
+  }
+
+  /// Stored in Firestore.
+  String get firestoreValue => switch (this) {
+        TripActivityCategory.sport => 'sport',
+        TripActivityCategory.shopping => 'shopping',
+        TripActivityCategory.visit => 'visit',
+        TripActivityCategory.restaurant => 'restaurant',
+      };
+}

--- a/lib/features/activities/presentation/trip_activities_page.dart
+++ b/lib/features/activities/presentation/trip_activities_page.dart
@@ -29,7 +29,7 @@ class TripActivitiesPage extends ConsumerWidget {
                 Text(
                   'Proposez des sorties : sport, shopping, visites, restaurants. '
                   'Chaque activite peut inclure un lien (apercu comme sur l\'apercu du voyage), '
-                  'un itineraire et des commentaires.',
+                  'une adresse pour le trajet depuis le logement, et des commentaires.',
                   style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                         color: Theme.of(context).colorScheme.onSurfaceVariant,
                       ),
@@ -71,7 +71,7 @@ class TripActivitiesPage extends ConsumerWidget {
   }
 }
 
-class _ActivityListTile extends StatelessWidget {
+class _ActivityListTile extends ConsumerWidget {
   const _ActivityListTile({
     required this.tripId,
     required this.activity,
@@ -91,38 +91,87 @@ class _ActivityListTile extends StatelessWidget {
     );
   }
 
+  Future<void> _setDone(
+    BuildContext context,
+    WidgetRef ref,
+    bool value,
+  ) async {
+    try {
+      await ref.read(activitiesRepositoryProvider).setActivityDone(
+            tripId: tripId,
+            activityId: activity.id,
+            done: value,
+          );
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Erreur: $e')),
+        );
+      }
+    }
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final label =
         activity.label.trim().isEmpty ? 'Sans titre' : activity.label.trim();
 
     return Card(
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: () => _openDetail(context),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Icon(
-                activity.category.categoryIcon,
-                size: 28,
-                color: Theme.of(context).colorScheme.primary,
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Text(
-                  label,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.titleMedium,
+      child: Padding(
+        padding: const EdgeInsets.only(left: 4, right: 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Checkbox(
+              value: activity.done,
+              onChanged: (v) {
+                if (v != null) _setDone(context, ref, v);
+              },
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              visualDensity: VisualDensity.compact,
+            ),
+            Expanded(
+              child: InkWell(
+                borderRadius: BorderRadius.circular(12),
+                onTap: () => _openDetail(context),
+                child: Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 10),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Icon(
+                        activity.category.categoryIcon,
+                        size: 28,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          label,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style:
+                              Theme.of(context).textTheme.titleMedium?.copyWith(
+                                    decoration: activity.done
+                                        ? TextDecoration.lineThrough
+                                        : null,
+                                    color: activity.done
+                                        ? Theme.of(context)
+                                            .colorScheme
+                                            .onSurfaceVariant
+                                        : null,
+                                  ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      LinkPreviewThumbnail(preview: activity.linkPreview),
+                    ],
+                  ),
                 ),
               ),
-              const SizedBox(width: 12),
-              LinkPreviewThumbnail(preview: activity.linkPreview),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
@@ -176,7 +225,7 @@ class _AddActivitySheetState extends ConsumerState<_AddActivitySheet> {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _labelController;
   late final TextEditingController _linkController;
-  late final TextEditingController _itineraryController;
+  late final TextEditingController _addressController;
   late final TextEditingController _commentsController;
   TripActivityCategory _category = TripActivityCategory.visit;
   bool _saving = false;
@@ -186,7 +235,7 @@ class _AddActivitySheetState extends ConsumerState<_AddActivitySheet> {
     super.initState();
     _labelController = TextEditingController();
     _linkController = TextEditingController();
-    _itineraryController = TextEditingController();
+    _addressController = TextEditingController();
     _commentsController = TextEditingController();
   }
 
@@ -194,7 +243,7 @@ class _AddActivitySheetState extends ConsumerState<_AddActivitySheet> {
   void dispose() {
     _labelController.dispose();
     _linkController.dispose();
-    _itineraryController.dispose();
+    _addressController.dispose();
     _commentsController.dispose();
     super.dispose();
   }
@@ -224,7 +273,7 @@ class _AddActivitySheetState extends ConsumerState<_AddActivitySheet> {
             label: _labelController.text,
             category: _category,
             linkUrl: _linkController.text,
-            itinerary: _itineraryController.text,
+            address: _addressController.text,
             freeComments: _commentsController.text,
           );
       if (!mounted) return;
@@ -303,23 +352,22 @@ class _AddActivitySheetState extends ConsumerState<_AddActivitySheet> {
             ),
             const SizedBox(height: 12),
             TextFormField(
-              controller: _itineraryController,
+              controller: _addressController,
               textInputAction: TextInputAction.next,
               decoration: const InputDecoration(
-                labelText: 'Itineraire',
-                hintText: 'Trajet, horaires, etapes...',
+                labelText: 'Adresse du lieu (trajet depuis le voyage)',
+                hintText: 'Pour calculer distance et duree en voiture',
                 border: OutlineInputBorder(),
-                alignLabelWithHint: true,
               ),
-              minLines: 2,
-              maxLines: 5,
+              minLines: 1,
+              maxLines: 3,
             ),
             const SizedBox(height: 12),
             TextFormField(
               controller: _commentsController,
               textInputAction: TextInputAction.done,
               decoration: const InputDecoration(
-                labelText: 'Commentaires libres',
+                labelText: 'Commentaires',
                 border: OutlineInputBorder(),
                 alignLabelWithHint: true,
               ),

--- a/lib/features/activities/presentation/trip_activities_page.dart
+++ b/lib/features/activities/presentation/trip_activities_page.dart
@@ -1,0 +1,346 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:planzers/features/activities/data/activities_repository.dart';
+import 'package:planzers/features/activities/data/trip_activity.dart';
+import 'package:planzers/features/activities/presentation/trip_activity_detail_page.dart';
+import 'package:planzers/features/trips/presentation/link_preview_from_firestore.dart';
+import 'package:planzers/features/trips/presentation/trip_scope.dart';
+
+class TripActivitiesPage extends ConsumerWidget {
+  const TripActivitiesPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final trip = TripScope.of(context);
+    final activitiesAsync = ref.watch(tripActivitiesStreamProvider(trip.id));
+
+    return Scaffold(
+      body: activitiesAsync.when(
+        data: (items) {
+          if (items.isEmpty) {
+            return ListView(
+              padding: const EdgeInsets.all(24),
+              children: [
+                Text(
+                  'Activites',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Proposez des sorties : sport, shopping, visites, restaurants. '
+                  'Chaque activite peut inclure un lien (apercu comme sur l\'apercu du voyage), '
+                  'un itineraire et des commentaires.',
+                  style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                ),
+              ],
+            );
+          }
+
+          return ListView.separated(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 88),
+            itemCount: items.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 8),
+            itemBuilder: (context, index) {
+              final a = items[index];
+              return _ActivityListTile(
+                tripId: trip.id,
+                activity: a,
+              );
+            },
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: Text(
+              'Erreur: $e',
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _openAddActivitySheet(context, ref, trip.id),
+        icon: const Icon(Icons.add),
+        label: const Text('Proposer'),
+      ),
+    );
+  }
+}
+
+class _ActivityListTile extends StatelessWidget {
+  const _ActivityListTile({
+    required this.tripId,
+    required this.activity,
+  });
+
+  final String tripId;
+  final TripActivity activity;
+
+  Future<void> _openDetail(BuildContext context) async {
+    await Navigator.of(context).push<void>(
+      MaterialPageRoute<void>(
+        builder: (context) => TripActivityDetailPage(
+          tripId: tripId,
+          activityId: activity.id,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final label =
+        activity.label.trim().isEmpty ? 'Sans titre' : activity.label.trim();
+
+    return Card(
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () => _openDetail(context),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Icon(
+                activity.category.categoryIcon,
+                size: 28,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  label,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
+              const SizedBox(width: 12),
+              LinkPreviewThumbnail(preview: activity.linkPreview),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> _openAddActivitySheet(
+  BuildContext context,
+  WidgetRef ref,
+  String tripId,
+) async {
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    showDragHandle: true,
+    builder: (sheetContext) {
+      return Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.viewInsetsOf(sheetContext).bottom,
+        ),
+        child: _AddActivitySheet(
+          tripId: tripId,
+          onSaved: () {
+            Navigator.of(sheetContext).pop();
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Activite ajoutee')),
+              );
+            }
+          },
+        ),
+      );
+    },
+  );
+}
+
+class _AddActivitySheet extends ConsumerStatefulWidget {
+  const _AddActivitySheet({
+    required this.tripId,
+    required this.onSaved,
+  });
+
+  final String tripId;
+  final VoidCallback onSaved;
+
+  @override
+  ConsumerState<_AddActivitySheet> createState() => _AddActivitySheetState();
+}
+
+class _AddActivitySheetState extends ConsumerState<_AddActivitySheet> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _labelController;
+  late final TextEditingController _linkController;
+  late final TextEditingController _itineraryController;
+  late final TextEditingController _commentsController;
+  TripActivityCategory _category = TripActivityCategory.visit;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _labelController = TextEditingController();
+    _linkController = TextEditingController();
+    _itineraryController = TextEditingController();
+    _commentsController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _labelController.dispose();
+    _linkController.dispose();
+    _itineraryController.dispose();
+    _commentsController.dispose();
+    super.dispose();
+  }
+
+  String? _validateOptionalUrl(String? value) {
+    final v = (value ?? '').trim();
+    if (v.isEmpty) return null;
+    final uri = Uri.tryParse(v);
+    if (uri == null || !uri.isAbsolute) {
+      return 'Lien invalide (ex: https://...)';
+    }
+    if (uri.scheme != 'http' && uri.scheme != 'https') {
+      return 'Le lien doit commencer par http(s)://';
+    }
+    return null;
+  }
+
+  Future<void> _submit() async {
+    if (_saving) return;
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+
+    setState(() => _saving = true);
+    try {
+      await ref.read(activitiesRepositoryProvider).addActivity(
+            tripId: widget.tripId,
+            label: _labelController.text,
+            category: _category,
+            linkUrl: _linkController.text,
+            itinerary: _itineraryController.text,
+            freeComments: _commentsController.text,
+          );
+      if (!mounted) return;
+      widget.onSaved();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Erreur: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(24, 8, 24, 24),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'Nouvelle activite',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Categorie',
+              style: Theme.of(context).textTheme.labelLarge,
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final c in TripActivityCategory.values)
+                  FilterChip(
+                    avatar: Icon(c.categoryIcon, size: 18),
+                    label: Text(c.categoryLabelFr),
+                    selected: _category == c,
+                    onSelected: _saving
+                        ? null
+                        : (_) => setState(() => _category = c),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _labelController,
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Libelle',
+                border: OutlineInputBorder(),
+              ),
+              validator: (value) {
+                if ((value ?? '').trim().isEmpty) {
+                  return 'Libelle obligatoire';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _linkController,
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Lien (site, billetterie, ...)',
+                hintText: 'https://...',
+                border: OutlineInputBorder(),
+              ),
+              keyboardType: TextInputType.url,
+              validator: _validateOptionalUrl,
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _itineraryController,
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Itineraire',
+                hintText: 'Trajet, horaires, etapes...',
+                border: OutlineInputBorder(),
+                alignLabelWithHint: true,
+              ),
+              minLines: 2,
+              maxLines: 5,
+            ),
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _commentsController,
+              textInputAction: TextInputAction.done,
+              decoration: const InputDecoration(
+                labelText: 'Commentaires libres',
+                border: OutlineInputBorder(),
+                alignLabelWithHint: true,
+              ),
+              minLines: 2,
+              maxLines: 6,
+              onFieldSubmitted: (_) => _submit(),
+            ),
+            const SizedBox(height: 20),
+            FilledButton(
+              onPressed: _saving ? null : _submit,
+              child: _saving
+                  ? const SizedBox(
+                      height: 22,
+                      width: 22,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Enregistrer'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/activities/presentation/trip_activity_detail_page.dart
+++ b/lib/features/activities/presentation/trip_activity_detail_page.dart
@@ -1,0 +1,544 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:planzers/features/activities/data/activities_repository.dart';
+import 'package:planzers/features/activities/data/trip_activity.dart';
+import 'package:planzers/features/trips/presentation/link_preview_from_firestore.dart';
+
+extension TripActivityCategoryPresentation on TripActivityCategory {
+  IconData get categoryIcon => switch (this) {
+        TripActivityCategory.sport => Icons.sports_soccer_outlined,
+        TripActivityCategory.shopping => Icons.shopping_bag_outlined,
+        TripActivityCategory.visit => Icons.museum_outlined,
+        TripActivityCategory.restaurant => Icons.restaurant_outlined,
+      };
+
+  String get categoryLabelFr => switch (this) {
+        TripActivityCategory.sport => 'Sport',
+        TripActivityCategory.shopping => 'Shopping',
+        TripActivityCategory.visit => 'Visite',
+        TripActivityCategory.restaurant => 'Restaurant',
+      };
+}
+
+class TripActivityDetailPage extends ConsumerStatefulWidget {
+  const TripActivityDetailPage({
+    super.key,
+    required this.tripId,
+    required this.activityId,
+  });
+
+  final String tripId;
+  final String activityId;
+
+  @override
+  ConsumerState<TripActivityDetailPage> createState() =>
+      _TripActivityDetailPageState();
+}
+
+class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _labelController;
+  late final TextEditingController _linkController;
+  late final TextEditingController _itineraryController;
+  late final TextEditingController _commentsController;
+  TripActivityCategory _category = TripActivityCategory.visit;
+  bool _editing = false;
+  bool _saving = false;
+  bool _deleting = false;
+  TripActivity? _lastSyncedActivity;
+
+  @override
+  void initState() {
+    super.initState();
+    _labelController = TextEditingController();
+    _linkController = TextEditingController();
+    _itineraryController = TextEditingController();
+    _commentsController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _labelController.dispose();
+    _linkController.dispose();
+    _itineraryController.dispose();
+    _commentsController.dispose();
+    super.dispose();
+  }
+
+  bool _sameEditableFields(TripActivity? prev, TripActivity next) {
+    if (prev == null) return false;
+    return prev.label == next.label &&
+        prev.linkUrl == next.linkUrl &&
+        prev.itinerary == next.itinerary &&
+        prev.freeComments == next.freeComments &&
+        prev.category == next.category;
+  }
+
+  void _syncControllersWhenIdle(TripActivity activity) {
+    if (_editing || _saving) return;
+    if (_sameEditableFields(_lastSyncedActivity, activity)) return;
+    _lastSyncedActivity = activity;
+    _labelController.text = activity.label;
+    _linkController.text = activity.linkUrl;
+    _itineraryController.text = activity.itinerary;
+    _commentsController.text = activity.freeComments;
+    _category = activity.category;
+  }
+
+  void _applyActivity(TripActivity activity) {
+    _labelController.text = activity.label;
+    _linkController.text = activity.linkUrl;
+    _itineraryController.text = activity.itinerary;
+    _commentsController.text = activity.freeComments;
+    _category = activity.category;
+    _lastSyncedActivity = activity;
+  }
+
+  String? _validateOptionalUrl(String? value) {
+    final v = (value ?? '').trim();
+    if (v.isEmpty) return null;
+    final uri = Uri.tryParse(v);
+    if (uri == null || !uri.isAbsolute) {
+      return 'Lien invalide (ex: https://...)';
+    }
+    if (uri.scheme != 'http' && uri.scheme != 'https') {
+      return 'Le lien doit commencer par http(s)://';
+    }
+    return null;
+  }
+
+  Future<void> _save() async {
+    if (_saving) return;
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+
+    setState(() => _saving = true);
+    try {
+      await ref.read(activitiesRepositoryProvider).updateActivity(
+            tripId: widget.tripId,
+            activityId: widget.activityId,
+            label: _labelController.text,
+            category: _category,
+            linkUrl: _linkController.text,
+            itinerary: _itineraryController.text,
+            freeComments: _commentsController.text,
+          );
+      if (!mounted) return;
+      setState(() => _editing = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Activite mise a jour')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Erreur: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  void _cancelEdit(TripActivity activity) {
+    _applyActivity(activity);
+    setState(() => _editing = false);
+  }
+
+  Future<void> _confirmAndDelete(TripActivity activity) async {
+    if (_deleting) return;
+    final label =
+        activity.label.trim().isEmpty ? 'Sans titre' : activity.label.trim();
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Supprimer cette activite ?'),
+        content: Text('« $label » sera supprimee.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Annuler'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Supprimer'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true || !mounted) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    setState(() => _deleting = true);
+    try {
+      await ref.read(activitiesRepositoryProvider).deleteActivity(
+            tripId: widget.tripId,
+            activityId: widget.activityId,
+          );
+      if (!mounted) return;
+      Navigator.of(context).pop();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Activite supprimee')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Erreur: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _deleting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final myUid = FirebaseAuth.instance.currentUser?.uid.trim();
+    final docRef = FirebaseFirestore.instance
+        .collection('trips')
+        .doc(widget.tripId.trim())
+        .collection('activities')
+        .doc(widget.activityId.trim());
+
+    return StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+      stream: docRef.snapshots(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting &&
+            !snapshot.hasData) {
+          return Scaffold(
+            appBar: AppBar(title: const Text('Activite')),
+            body: const Center(child: CircularProgressIndicator()),
+          );
+        }
+        final doc = snapshot.data;
+        if (doc == null || !doc.exists) {
+          return Scaffold(
+            appBar: AppBar(title: const Text('Activite')),
+            body: const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text(
+                  'Activite introuvable.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+          );
+        }
+
+        final activity = TripActivity.fromDoc(doc);
+        _syncControllersWhenIdle(activity);
+
+        final createdBy = activity.createdBy.trim();
+        final canEdit =
+            myUid != null && myUid.isNotEmpty && createdBy == myUid;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Activite'),
+            actions: [
+              if (canEdit && !_editing) ...[
+                IconButton(
+                  tooltip: 'Modifier',
+                  onPressed: _deleting
+                      ? null
+                      : () => setState(() => _editing = true),
+                  icon: const Icon(Icons.edit_outlined),
+                ),
+                IconButton(
+                  tooltip: 'Supprimer',
+                  onPressed: _deleting
+                      ? null
+                      : () => _confirmAndDelete(activity),
+                  icon: _deleting
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.delete_outline),
+                ),
+              ],
+              if (canEdit && _editing) ...[
+                IconButton(
+                  tooltip: 'Annuler',
+                  onPressed: _saving ? null : () => _cancelEdit(activity),
+                  icon: const Icon(Icons.close),
+                ),
+                IconButton(
+                  tooltip: 'Enregistrer',
+                  onPressed: _saving ? null : _save,
+                  icon: _saving
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.check),
+                ),
+              ],
+            ],
+          ),
+          body: _editing
+              ? _EditBody(
+                  formKey: _formKey,
+                  labelController: _labelController,
+                  linkController: _linkController,
+                  itineraryController: _itineraryController,
+                  commentsController: _commentsController,
+                  category: _category,
+                  onCategoryChanged: _saving
+                      ? null
+                      : (c) => setState(() => _category = c),
+                  activity: activity,
+                  validateOptionalUrl: _validateOptionalUrl,
+                )
+              : _ReadBody(activity: activity),
+        );
+      },
+    );
+  }
+}
+
+class _ReadBody extends StatelessWidget {
+  const _ReadBody({required this.activity});
+
+  final TripActivity activity;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              activity.category.categoryIcon,
+              size: 40,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    activity.category.categoryLabelFr,
+                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                          color:
+                              Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    activity.label.isEmpty ? 'Sans titre' : activity.label,
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 20),
+        if (activity.linkUrl.trim().isNotEmpty) ...[
+          LinkPreviewCardFromFirestore(
+            url: activity.linkUrl.trim(),
+            preview: activity.linkPreview,
+          ),
+          const SizedBox(height: 16),
+        ],
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Itineraire',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  activity.itinerary.trim().isEmpty
+                      ? '—'
+                      : activity.itinerary.trim(),
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Commentaires libres',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  activity.freeComments.trim().isEmpty
+                      ? '—'
+                      : activity.freeComments.trim(),
+                  style: Theme.of(context).textTheme.bodyLarge,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _EditBody extends StatefulWidget {
+  const _EditBody({
+    required this.formKey,
+    required this.labelController,
+    required this.linkController,
+    required this.itineraryController,
+    required this.commentsController,
+    required this.category,
+    required this.onCategoryChanged,
+    required this.activity,
+    required this.validateOptionalUrl,
+  });
+
+  final GlobalKey<FormState> formKey;
+  final TextEditingController labelController;
+  final TextEditingController linkController;
+  final TextEditingController itineraryController;
+  final TextEditingController commentsController;
+  final TripActivityCategory category;
+  final void Function(TripActivityCategory)? onCategoryChanged;
+  final TripActivity activity;
+  final String? Function(String?) validateOptionalUrl;
+
+  @override
+  State<_EditBody> createState() => _EditBodyState();
+}
+
+class _EditBodyState extends State<_EditBody> {
+  @override
+  void initState() {
+    super.initState();
+    widget.linkController.addListener(_onLinkChanged);
+  }
+
+  @override
+  void dispose() {
+    widget.linkController.removeListener(_onLinkChanged);
+    super.dispose();
+  }
+
+  void _onLinkChanged() => setState(() {});
+
+  @override
+  Widget build(BuildContext context) {
+    final linkTrimmed = widget.linkController.text.trim();
+    final savedLink = widget.activity.linkUrl.trim();
+    final showLivePreview =
+        linkTrimmed.isNotEmpty && linkTrimmed == savedLink;
+
+    return Form(
+      key: widget.formKey,
+      child: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            'Categorie',
+            style: Theme.of(context).textTheme.labelLarge,
+          ),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              for (final c in TripActivityCategory.values)
+                FilterChip(
+                  avatar: Icon(c.categoryIcon, size: 18),
+                  label: Text(c.categoryLabelFr),
+                  selected: widget.category == c,
+                  onSelected: widget.onCategoryChanged == null
+                      ? null
+                      : (_) => widget.onCategoryChanged!(c),
+                ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          TextFormField(
+            controller: widget.labelController,
+            textInputAction: TextInputAction.next,
+            decoration: const InputDecoration(
+              labelText: 'Libelle',
+              border: OutlineInputBorder(),
+            ),
+            validator: (value) {
+              if ((value ?? '').trim().isEmpty) {
+                return 'Libelle obligatoire';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: widget.linkController,
+            textInputAction: TextInputAction.next,
+            decoration: const InputDecoration(
+              labelText: 'Lien (site, billetterie, ...)',
+              hintText: 'https://...',
+              border: OutlineInputBorder(),
+            ),
+            keyboardType: TextInputType.url,
+            validator: widget.validateOptionalUrl,
+          ),
+          if (linkTrimmed.isNotEmpty && !showLivePreview) ...[
+            const SizedBox(height: 8),
+            Text(
+              'L\'apercu du lien sera mis a jour apres enregistrement.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+            ),
+          ],
+          if (showLivePreview) ...[
+            const SizedBox(height: 12),
+            LinkPreviewCardFromFirestore(
+              url: linkTrimmed,
+              preview: widget.activity.linkPreview,
+            ),
+          ],
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: widget.itineraryController,
+            textInputAction: TextInputAction.next,
+            decoration: const InputDecoration(
+              labelText: 'Itineraire',
+              hintText: 'Trajet, horaires, etapes...',
+              border: OutlineInputBorder(),
+              alignLabelWithHint: true,
+            ),
+            minLines: 2,
+            maxLines: 5,
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: widget.commentsController,
+            textInputAction: TextInputAction.done,
+            decoration: const InputDecoration(
+              labelText: 'Commentaires libres',
+              border: OutlineInputBorder(),
+              alignLabelWithHint: true,
+            ),
+            minLines: 2,
+            maxLines: 6,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/activities/presentation/trip_activity_detail_page.dart
+++ b/lib/features/activities/presentation/trip_activity_detail_page.dart
@@ -41,7 +41,7 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _labelController;
   late final TextEditingController _linkController;
-  late final TextEditingController _itineraryController;
+  late final TextEditingController _addressController;
   late final TextEditingController _commentsController;
   TripActivityCategory _category = TripActivityCategory.visit;
   bool _editing = false;
@@ -54,7 +54,7 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
     super.initState();
     _labelController = TextEditingController();
     _linkController = TextEditingController();
-    _itineraryController = TextEditingController();
+    _addressController = TextEditingController();
     _commentsController = TextEditingController();
   }
 
@@ -62,7 +62,7 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
   void dispose() {
     _labelController.dispose();
     _linkController.dispose();
-    _itineraryController.dispose();
+    _addressController.dispose();
     _commentsController.dispose();
     super.dispose();
   }
@@ -71,9 +71,10 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
     if (prev == null) return false;
     return prev.label == next.label &&
         prev.linkUrl == next.linkUrl &&
-        prev.itinerary == next.itinerary &&
+        prev.address == next.address &&
         prev.freeComments == next.freeComments &&
-        prev.category == next.category;
+        prev.category == next.category &&
+        prev.done == next.done;
   }
 
   void _syncControllersWhenIdle(TripActivity activity) {
@@ -82,7 +83,7 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
     _lastSyncedActivity = activity;
     _labelController.text = activity.label;
     _linkController.text = activity.linkUrl;
-    _itineraryController.text = activity.itinerary;
+    _addressController.text = activity.address;
     _commentsController.text = activity.freeComments;
     _category = activity.category;
   }
@@ -90,7 +91,7 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
   void _applyActivity(TripActivity activity) {
     _labelController.text = activity.label;
     _linkController.text = activity.linkUrl;
-    _itineraryController.text = activity.itinerary;
+    _addressController.text = activity.address;
     _commentsController.text = activity.freeComments;
     _category = activity.category;
     _lastSyncedActivity = activity;
@@ -122,7 +123,7 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
             label: _labelController.text,
             category: _category,
             linkUrl: _linkController.text,
-            itinerary: _itineraryController.text,
+            address: _addressController.text,
             freeComments: _commentsController.text,
           );
       if (!mounted) return;
@@ -283,7 +284,7 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
                   formKey: _formKey,
                   labelController: _labelController,
                   linkController: _linkController,
-                  itineraryController: _itineraryController,
+                  addressController: _addressController,
                   commentsController: _commentsController,
                   category: _category,
                   onCategoryChanged: _saving
@@ -292,20 +293,43 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
                   activity: activity,
                   validateOptionalUrl: _validateOptionalUrl,
                 )
-              : _ReadBody(activity: activity),
+              : _ReadBody(
+                  tripId: widget.tripId,
+                  activity: activity,
+                ),
         );
       },
     );
   }
 }
 
-class _ReadBody extends StatelessWidget {
-  const _ReadBody({required this.activity});
+class _ReadBody extends ConsumerWidget {
+  const _ReadBody({
+    required this.tripId,
+    required this.activity,
+  });
 
+  final String tripId;
   final TripActivity activity;
 
+  Future<void> _toggleDone(WidgetRef ref, BuildContext context, bool value) async {
+    try {
+      await ref.read(activitiesRepositoryProvider).setActivityDone(
+            tripId: tripId,
+            activityId: activity.id,
+            done: value,
+          );
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Erreur: $e')),
+        );
+      }
+    }
+  }
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -332,20 +356,87 @@ class _ReadBody extends StatelessWidget {
                   const SizedBox(height: 4),
                   Text(
                     activity.label.isEmpty ? 'Sans titre' : activity.label,
-                    style: Theme.of(context).textTheme.headlineSmall,
+                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                          decoration: activity.done
+                              ? TextDecoration.lineThrough
+                              : null,
+                          color: activity.done
+                              ? Theme.of(context).colorScheme.onSurfaceVariant
+                              : null,
+                        ),
                   ),
                 ],
               ),
             ),
           ],
         ),
-        const SizedBox(height: 20),
+        const SizedBox(height: 8),
+        CheckboxListTile(
+          value: activity.done,
+          onChanged: (v) {
+            if (v != null) _toggleDone(ref, context, v);
+          },
+          title: const Text('Faite'),
+          controlAffinity: ListTileControlAffinity.leading,
+          contentPadding: EdgeInsets.zero,
+        ),
+        const SizedBox(height: 12),
         if (activity.linkUrl.trim().isNotEmpty) ...[
           LinkPreviewCardFromFirestore(
             url: activity.linkUrl.trim(),
             preview: activity.linkPreview,
           ),
           const SizedBox(height: 16),
+        ],
+        if (activity.address.trim().isNotEmpty) ...[
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Adresse du lieu',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    activity.address.trim(),
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Icon(
+                        Icons.directions_car_outlined,
+                        size: 22,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Depuis le logement (voiture)',
+                              style: Theme.of(context).textTheme.labelLarge,
+                            ),
+                            const SizedBox(height: 6),
+                            Text(
+                              _activityDrivingRouteBodyText(activity),
+                              style: Theme.of(context).textTheme.bodyMedium,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
         ],
         Card(
           child: Padding(
@@ -354,29 +445,7 @@ class _ReadBody extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Itineraire',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  activity.itinerary.trim().isEmpty
-                      ? '—'
-                      : activity.itinerary.trim(),
-                  style: Theme.of(context).textTheme.bodyLarge,
-                ),
-              ],
-            ),
-          ),
-        ),
-        const SizedBox(height: 12),
-        Card(
-          child: Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Commentaires libres',
+                  'Commentaires',
                   style: Theme.of(context).textTheme.titleMedium,
                 ),
                 const SizedBox(height: 8),
@@ -400,7 +469,7 @@ class _EditBody extends StatefulWidget {
     required this.formKey,
     required this.labelController,
     required this.linkController,
-    required this.itineraryController,
+    required this.addressController,
     required this.commentsController,
     required this.category,
     required this.onCategoryChanged,
@@ -411,7 +480,7 @@ class _EditBody extends StatefulWidget {
   final GlobalKey<FormState> formKey;
   final TextEditingController labelController;
   final TextEditingController linkController;
-  final TextEditingController itineraryController;
+  final TextEditingController addressController;
   final TextEditingController commentsController;
   final TripActivityCategory category;
   final void Function(TripActivityCategory)? onCategoryChanged;
@@ -514,23 +583,22 @@ class _EditBodyState extends State<_EditBody> {
           ],
           const SizedBox(height: 12),
           TextFormField(
-            controller: widget.itineraryController,
+            controller: widget.addressController,
             textInputAction: TextInputAction.next,
             decoration: const InputDecoration(
-              labelText: 'Itineraire',
-              hintText: 'Trajet, horaires, etapes...',
+              labelText: 'Adresse du lieu (trajet depuis le voyage)',
+              hintText: 'Pour calculer distance et duree en voiture',
               border: OutlineInputBorder(),
-              alignLabelWithHint: true,
             ),
-            minLines: 2,
-            maxLines: 5,
+            minLines: 1,
+            maxLines: 3,
           ),
           const SizedBox(height: 12),
           TextFormField(
             controller: widget.commentsController,
             textInputAction: TextInputAction.done,
             decoration: const InputDecoration(
-              labelText: 'Commentaires libres',
+              labelText: 'Commentaires',
               border: OutlineInputBorder(),
               alignLabelWithHint: true,
             ),
@@ -540,5 +608,34 @@ class _EditBodyState extends State<_EditBody> {
         ],
       ),
     );
+  }
+}
+
+String _activityDrivingRouteBodyText(TripActivity activity) {
+  final route = activity.tripDrivingRoute;
+
+  if (route == null) {
+    return 'Calcul en cours depuis l\'adresse du voyage.';
+  }
+  switch (route.status) {
+    case 'ok':
+      final dist = route.distanceText?.trim();
+      final dur = route.durationText?.trim();
+      if ((dist != null && dist.isNotEmpty) ||
+          (dur != null && dur.isNotEmpty)) {
+        return [
+          if (dist != null && dist.isNotEmpty) 'Distance : $dist',
+          if (dur != null && dur.isNotEmpty) 'Duree : $dur',
+        ].join('\n');
+      }
+      return 'Trajet calcule.';
+    case 'missing_trip_address':
+      return 'Adresse du voyage manquante : renseignez-la dans l\'apercu du voyage.';
+    case 'no_result':
+      return 'Aucun trajet trouve${route.detail != null && route.detail!.isNotEmpty ? ' (${route.detail})' : ''}.';
+    case 'error':
+      return 'Impossible de calculer le trajet${route.errorMessage != null && route.errorMessage!.isNotEmpty ? ' : ${route.errorMessage}' : ''}.';
+    default:
+      return 'Statut : ${route.status}';
   }
 }

--- a/lib/features/activities/presentation/trip_activity_detail_page.dart
+++ b/lib/features/activities/presentation/trip_activity_detail_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:planzers/features/activities/data/activities_repository.dart';
 import 'package:planzers/features/activities/data/trip_activity.dart';
 import 'package:planzers/features/trips/presentation/link_preview_from_firestore.dart';
+import 'package:planzers/features/trips/presentation/open_address_in_google_maps.dart';
 
 extension TripActivityCategoryPresentation on TripActivityCategory {
   IconData get categoryIcon => switch (this) {
@@ -400,9 +401,24 @@ class _ReadBody extends ConsumerWidget {
                     style: Theme.of(context).textTheme.titleMedium,
                   ),
                   const SizedBox(height: 8),
-                  Text(
-                    activity.address.trim(),
-                    style: Theme.of(context).textTheme.bodyLarge,
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          activity.address.trim(),
+                          style: Theme.of(context).textTheme.bodyLarge,
+                        ),
+                      ),
+                      IconButton(
+                        tooltip: 'Ouvrir la localisation',
+                        onPressed: () => openAddressInGoogleMaps(
+                              context,
+                              activity.address,
+                            ),
+                        icon: const Icon(Icons.location_on_outlined),
+                      ),
+                    ],
                   ),
                   const SizedBox(height: 16),
                   Row(

--- a/lib/features/trips/presentation/link_preview_from_firestore.dart
+++ b/lib/features/trips/presentation/link_preview_from_firestore.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Renders Open Graph / meta preview data stored on a Firestore document
+/// (`linkPreview` map), same shape as trip overview and trip activities.
+class LinkPreviewCardFromFirestore extends StatelessWidget {
+  const LinkPreviewCardFromFirestore({
+    super.key,
+    required this.url,
+    required this.preview,
+    this.titleLabel = 'Lien',
+  });
+
+  final String url;
+  final Map<String, dynamic> preview;
+  final String titleLabel;
+
+  Future<void> _openLink(BuildContext context) async {
+    final parsed = Uri.tryParse(url.trim());
+    if (parsed == null || !parsed.isAbsolute) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Lien invalide')),
+      );
+      return;
+    }
+
+    final didLaunch = await launchUrl(
+      parsed,
+      mode: LaunchMode.platformDefault,
+      webOnlyWindowName: '_blank',
+    );
+
+    if (!didLaunch && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Impossible d\'ouvrir le lien')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final status = (preview['status'] as String?) ?? '';
+    final title = (preview['title'] as String?) ?? '';
+    final description = (preview['description'] as String?) ?? '';
+    final siteName = (preview['siteName'] as String?) ?? '';
+    final imageUrl = (preview['imageUrl'] as String?) ?? '';
+
+    final hasPreview = title.trim().isNotEmpty ||
+        description.trim().isNotEmpty ||
+        imageUrl.trim().isNotEmpty ||
+        siteName.trim().isNotEmpty;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(titleLabel, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            InkWell(
+              onTap: () => _openLink(context),
+              borderRadius: BorderRadius.circular(6),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      url,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Theme.of(context).colorScheme.primary,
+                            decoration: TextDecoration.underline,
+                          ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Icon(
+                    Icons.open_in_new,
+                    size: 18,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+            if (status == 'loading') ...[
+              const SizedBox(
+                height: 120,
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            ] else if (!hasPreview) ...[
+              Text(
+                'Apercu indisponible pour ce lien.',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ] else ...[
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (imageUrl.trim().isNotEmpty) ...[
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: Image.network(
+                        imageUrl,
+                        width: 96,
+                        height: 96,
+                        fit: BoxFit.cover,
+                        webHtmlElementStrategy: kIsWeb
+                            ? WebHtmlElementStrategy.prefer
+                            : WebHtmlElementStrategy.never,
+                        errorBuilder: (_, __, ___) => Container(
+                          width: 96,
+                          height: 96,
+                          color: Colors.black12,
+                          alignment: Alignment.center,
+                          child: const Icon(Icons.broken_image_outlined),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                  ],
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (siteName.trim().isNotEmpty) ...[
+                          Text(
+                            siteName,
+                            style: Theme.of(context).textTheme.labelLarge,
+                          ),
+                          const SizedBox(height: 4),
+                        ],
+                        if (title.trim().isNotEmpty) ...[
+                          Text(
+                            title,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.titleSmall,
+                          ),
+                        ],
+                        if (description.trim().isNotEmpty) ...[
+                          const SizedBox(height: 4),
+                          Text(
+                            description,
+                            maxLines: 3,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Compact preview image for list rows (activity list, etc.).
+class LinkPreviewThumbnail extends StatelessWidget {
+  const LinkPreviewThumbnail({
+    super.key,
+    required this.preview,
+    this.size = 56,
+  });
+
+  final Map<String, dynamic> preview;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final status = (preview['status'] as String?) ?? '';
+    final imageUrl = (preview['imageUrl'] as String?) ?? '';
+
+    if (status == 'loading') {
+      return SizedBox(
+        width: size,
+        height: size,
+        child: const Center(
+          child: SizedBox(
+            width: 24,
+            height: 24,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        ),
+      );
+    }
+
+    if (imageUrl.trim().isEmpty) {
+      return Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        alignment: Alignment.center,
+        child: Icon(
+          Icons.link,
+          size: size * 0.45,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      );
+    }
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: Image.network(
+        imageUrl,
+        width: size,
+        height: size,
+        fit: BoxFit.cover,
+        webHtmlElementStrategy: kIsWeb
+            ? WebHtmlElementStrategy.prefer
+            : WebHtmlElementStrategy.never,
+        errorBuilder: (_, __, ___) => Container(
+          width: size,
+          height: size,
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          alignment: Alignment.center,
+          child: Icon(
+            Icons.broken_image_outlined,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/trips/presentation/open_address_in_google_maps.dart
+++ b/lib/features/trips/presentation/open_address_in_google_maps.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Opens [address] in Google Maps search (same behaviour as trip overview).
+Future<void> openAddressInGoogleMaps(
+  BuildContext context,
+  String address,
+) async {
+  final query = address.trim();
+  if (query.isEmpty) return;
+
+  final mapsUri = Uri.https(
+    'www.google.com',
+    '/maps/search/',
+    <String, String>{
+      'api': '1',
+      'query': query,
+    },
+  );
+
+  final didLaunch = await launchUrl(
+    mapsUri,
+    mode: LaunchMode.platformDefault,
+  );
+
+  if (!didLaunch && context.mounted) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Impossible d\'ouvrir la localisation')),
+    );
+  }
+}

--- a/lib/features/trips/presentation/trip_overview_page.dart
+++ b/lib/features/trips/presentation/trip_overview_page.dart
@@ -1,7 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:planzers/features/auth/data/user_display_label.dart';
 import 'package:planzers/features/trips/data/trip.dart';
 import 'package:planzers/features/trips/data/trips_repository.dart';
+import 'package:planzers/features/trips/presentation/link_preview_from_firestore.dart';
 import 'package:planzers/features/trips/presentation/trip_date_format.dart';
 import 'package:planzers/features/trips/presentation/trip_scope.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -551,7 +551,7 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
               const SizedBox(height: 16),
             ],
             if (linkUrlForUi.isNotEmpty) ...[
-              _LinkPreviewCardFromFirestore(
+              LinkPreviewCardFromFirestore(
                 url: linkUrlForUi,
                 preview: livePreview,
               ),
@@ -905,159 +905,6 @@ class _MembersInfoRow extends StatelessWidget {
           ],
         );
       },
-    );
-  }
-}
-
-class _LinkPreviewCardFromFirestore extends StatelessWidget {
-  const _LinkPreviewCardFromFirestore({
-    required this.url,
-    required this.preview,
-  });
-
-  final String url;
-  final Map<String, dynamic> preview;
-
-  Future<void> _openLink(BuildContext context) async {
-    final parsed = Uri.tryParse(url.trim());
-    if (parsed == null || !parsed.isAbsolute) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Lien invalide')),
-      );
-      return;
-    }
-
-    final didLaunch = await launchUrl(
-      parsed,
-      mode: LaunchMode.platformDefault,
-      webOnlyWindowName: '_blank',
-    );
-
-    if (!didLaunch && context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Impossible d\'ouvrir le lien')),
-      );
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final status = (preview['status'] as String?) ?? '';
-    final title = (preview['title'] as String?) ?? '';
-    final description = (preview['description'] as String?) ?? '';
-    final siteName = (preview['siteName'] as String?) ?? '';
-    final imageUrl = (preview['imageUrl'] as String?) ?? '';
-
-    final hasPreview = title.trim().isNotEmpty ||
-        description.trim().isNotEmpty ||
-        imageUrl.trim().isNotEmpty ||
-        siteName.trim().isNotEmpty;
-
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Lien', style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            InkWell(
-              onTap: () => _openLink(context),
-              borderRadius: BorderRadius.circular(6),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      url,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            color: Theme.of(context).colorScheme.primary,
-                            decoration: TextDecoration.underline,
-                          ),
-                    ),
-                  ),
-                  const SizedBox(width: 8),
-                  Icon(
-                    Icons.open_in_new,
-                    size: 18,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 12),
-            if (status == 'loading') ...[
-              const SizedBox(
-                height: 120,
-                child: Center(child: CircularProgressIndicator()),
-              ),
-            ] else if (!hasPreview) ...[
-              Text(
-                'Apercu indisponible pour ce lien.',
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-            ] else ...[
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  if (imageUrl.trim().isNotEmpty) ...[
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: Image.network(
-                        imageUrl,
-                        width: 96,
-                        height: 96,
-                        fit: BoxFit.cover,
-                        webHtmlElementStrategy: kIsWeb
-                            ? WebHtmlElementStrategy.prefer
-                            : WebHtmlElementStrategy.never,
-                        errorBuilder: (_, __, ___) => Container(
-                          width: 96,
-                          height: 96,
-                          color: Colors.black12,
-                          alignment: Alignment.center,
-                          child: const Icon(Icons.broken_image_outlined),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                  ],
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        if (siteName.trim().isNotEmpty) ...[
-                          Text(
-                            siteName,
-                            style: Theme.of(context).textTheme.labelLarge,
-                          ),
-                          const SizedBox(height: 4),
-                        ],
-                        if (title.trim().isNotEmpty) ...[
-                          Text(
-                            title,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.titleSmall,
-                          ),
-                        ],
-                        if (description.trim().isNotEmpty) ...[
-                          const SizedBox(height: 4),
-                          Text(
-                            description,
-                            maxLines: 3,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.bodySmall,
-                          ),
-                        ],
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/features/trips/presentation/trip_overview_page.dart
+++ b/lib/features/trips/presentation/trip_overview_page.dart
@@ -9,10 +9,9 @@ import 'package:planzers/features/auth/data/user_display_label.dart';
 import 'package:planzers/features/trips/data/trip.dart';
 import 'package:planzers/features/trips/data/trips_repository.dart';
 import 'package:planzers/features/trips/presentation/link_preview_from_firestore.dart';
+import 'package:planzers/features/trips/presentation/open_address_in_google_maps.dart';
 import 'package:planzers/features/trips/presentation/trip_date_format.dart';
 import 'package:planzers/features/trips/presentation/trip_scope.dart';
-import 'package:url_launcher/url_launcher.dart';
-
 class TripOverviewPage extends ConsumerStatefulWidget {
   const TripOverviewPage({super.key});
 
@@ -89,31 +88,6 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
       _editStartDate = trip.startDate;
       _editEndDate = trip.endDate;
     });
-  }
-
-  Future<void> _openAddressLocation(String address) async {
-    final query = address.trim();
-    if (query.isEmpty) return;
-
-    final mapsUri = Uri.https(
-      'www.google.com',
-      '/maps/search/',
-      <String, String>{
-        'api': '1',
-        'query': query,
-      },
-    );
-
-    final didLaunch = await launchUrl(
-      mapsUri,
-      mode: LaunchMode.platformDefault,
-    );
-
-    if (!didLaunch && mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Impossible d\'ouvrir la localisation')),
-      );
-    }
   }
 
   Future<void> _save() async {
@@ -571,7 +545,10 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
                       actionIcon: Icons.location_on_outlined,
                       onActionPressed: _trip.address.trim().isEmpty
                           ? null
-                          : () => _openAddressLocation(_trip.address),
+                          : () => openAddressInGoogleMaps(
+                                context,
+                                _trip.address,
+                              ),
                       actionTooltip: 'Ouvrir la localisation',
                     ),
                     const SizedBox(height: 12),

--- a/lib/features/trips/presentation/trip_shell_page.dart
+++ b/lib/features/trips/presentation/trip_shell_page.dart
@@ -234,19 +234,6 @@ class TripMealsPage extends StatelessWidget {
   }
 }
 
-class TripActivitiesPage extends StatelessWidget {
-  const TripActivitiesPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return _TripSectionPlaceholder(
-      title: 'Activités',
-      icon: Icons.event_available_outlined,
-      message: 'Activités et sorties du voyage. Contenu à venir.',
-    );
-  }
-}
-
 class _TripSectionPlaceholder extends StatelessWidget {
   const _TripSectionPlaceholder({
     required this.title,


### PR DESCRIPTION
This pull request introduces a complete backend and data-layer implementation for trip activities, including support for link previews and driving route calculations from the trip address to activity locations. It adds new Cloud Functions to handle Firestore triggers for activities, implements repository and model classes in Dart for activities and their associated metadata, and integrates with Google Maps for driving distance calculations.

**Backend: Cloud Functions for Activities and Driving Routes**
- Added Cloud Functions triggered on activity and trip document writes to:
  - Generate and update link previews for both trips and activities.
  - Compute driving distance and duration from the trip's address to each activity's address using the Google Maps Distance Matrix API, with results stored in the activity document. [[1]](diffhunk://#diff-6c53bf76483f89e4e126787e25a40c3d7001cf6590b587c621e2e462cdbc8060L2-R50) [[2]](diffhunk://#diff-6c53bf76483f89e4e126787e25a40c3d7001cf6590b587c621e2e462cdbc8060R137-R221) [[3]](diffhunk://#diff-6c53bf76483f89e4e126787e25a40c3d7001cf6590b587c621e2e462cdbc8060L189-R452)

**Dart Data Layer: Activities Repository and Models**
- Implemented `ActivitiesRepository` with methods to add, update, delete, and stream activities for a trip, enforcing user permissions and Firestore rules.
- Added `TripActivity` model to represent an activity, including fields for link preview and driving route metadata, and an enum for activity categories.
- Added `ActivityTripDrivingRoute` model to deserialize and represent driving route information from Firestore.

**Integration**
- Registered the new activities page in the app router to enable navigation to trip activities.