### PR TITLE
Remove activity lock option from trip activities

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -29,17 +29,6 @@ service cloud.firestore {
         ).data.memberIds;
     }
 
-    function isTripAdmin(tripId) {
-      return isTripMember(tripId)
-        && (
-          tripDoc(tripId).data.ownerId == request.auth.uid
-          || (
-            tripDoc(tripId).data.adminMemberIds is list
-            && request.auth.uid in tripDoc(tripId).data.adminMemberIds
-          )
-        );
-    }
-
     function tripCallerRoleRank(tripId) {
       return tripDoc(tripId).data.ownerId == request.auth.uid
         ? 2
@@ -209,10 +198,6 @@ service cloud.firestore {
         && tripCallerRoleRank(tripId) >= roleRank(tripDeleteRegisteredParticipantMinRole(tripId));
     }
 
-    function activityLocked(data) {
-      return data.keys().hasAny(['isLocked']) && data.isLocked == true;
-    }
-
     function canReadTrip(data) {
       return signedIn()
         && (
@@ -359,11 +344,7 @@ service cloud.firestore {
       match /activities/{activityId} {
         allow read: if isTripMember(tripId);
         allow create: if isTripMember(tripId);
-        allow update, delete: if isTripMember(tripId)
-          && (
-            !activityLocked(resource.data)
-            || isTripAdmin(tripId)
-          );
+        allow update, delete: if isTripMember(tripId);
       }
 
       match /shoppingItems/{itemId} {

--- a/lib/features/activities/data/activities_repository.dart
+++ b/lib/features/activities/data/activities_repository.dart
@@ -30,30 +30,6 @@ class ActivitiesRepository {
     return firestore.collection('trips').doc(tripId).collection('activities');
   }
 
-  Future<bool> _isTripAdmin(String tripId, String userId) async {
-    final tripSnap = await firestore.collection('trips').doc(tripId).get();
-    final tripData = tripSnap.data() ?? const <String, dynamic>{};
-    final ownerId = (tripData['ownerId'] as String?)?.trim() ?? '';
-    if (ownerId.isNotEmpty && ownerId == userId) return true;
-    final admins = (tripData['adminMemberIds'] as List<dynamic>? ?? const [])
-        .map((e) => e.toString().trim())
-        .where((id) => id.isNotEmpty);
-    return admins.contains(userId);
-  }
-
-  Future<void> _assertCanModifyActivity({
-    required String tripId,
-    required String userId,
-    required Map<String, dynamic> activityData,
-  }) async {
-    final isLocked = activityData['isLocked'] == true;
-    if (!isLocked) return;
-    final isAdmin = await _isTripAdmin(tripId, userId);
-    if (!isAdmin) {
-      throw StateError('Activite verrouillee: modification reservee aux admins');
-    }
-  }
-
   Stream<List<TripActivity>> watchTripActivities(String tripId) {
     final cleanId = tripId.trim();
     if (cleanId.isEmpty) {
@@ -73,7 +49,6 @@ class ActivitiesRepository {
     required String linkUrl,
     required String address,
     required String freeComments,
-    required bool isLocked,
   }) async {
     final user = auth.currentUser;
     if (user == null) {
@@ -97,7 +72,6 @@ class ActivitiesRepository {
       'address': address.trim(),
       'freeComments': freeComments.trim(),
       'done': false,
-      'isLocked': isLocked,
       'createdBy': user.uid,
       'createdAt': FieldValue.serverTimestamp(),
     });
@@ -125,11 +99,6 @@ class ActivitiesRepository {
     if (!snap.exists) {
       throw StateError('Activite introuvable');
     }
-    await _assertCanModifyActivity(
-      tripId: cleanTripId,
-      userId: user.uid,
-      activityData: snap.data() ?? const <String, dynamic>{},
-    );
 
     await docRef.update({
       'done': done,
@@ -159,11 +128,6 @@ class ActivitiesRepository {
     if (!snap.exists) {
       throw StateError('Activite introuvable');
     }
-    await _assertCanModifyActivity(
-      tripId: cleanTripId,
-      userId: user.uid,
-      activityData: snap.data() ?? const <String, dynamic>{},
-    );
 
     await docRef.update({
       'plannedAt':
@@ -180,7 +144,6 @@ class ActivitiesRepository {
     required String linkUrl,
     required String address,
     required String freeComments,
-    required bool isLocked,
   }) async {
     final user = auth.currentUser;
     if (user == null) {
@@ -203,11 +166,6 @@ class ActivitiesRepository {
     if (!snap.exists) {
       throw StateError('Activite introuvable');
     }
-    await _assertCanModifyActivity(
-      tripId: cleanTripId,
-      userId: user.uid,
-      activityData: snap.data() ?? const <String, dynamic>{},
-    );
 
     await docRef.update({
       'label': cleanLabel,
@@ -215,7 +173,6 @@ class ActivitiesRepository {
       'linkUrl': linkUrl.trim(),
       'address': address.trim(),
       'freeComments': freeComments.trim(),
-      'isLocked': isLocked,
       'itinerary': FieldValue.delete(),
       'updatedAt': FieldValue.serverTimestamp(),
     });
@@ -241,11 +198,6 @@ class ActivitiesRepository {
     if (!snap.exists) {
       throw StateError('Activite introuvable');
     }
-    await _assertCanModifyActivity(
-      tripId: cleanTripId,
-      userId: user.uid,
-      activityData: snap.data() ?? const <String, dynamic>{},
-    );
 
     await docRef.delete();
   }

--- a/lib/features/activities/data/trip_activity.dart
+++ b/lib/features/activities/data/trip_activity.dart
@@ -14,7 +14,6 @@ class TripActivity {
     required this.createdBy,
     required this.createdAt,
     this.done = false,
-    this.isLocked = false,
     this.plannedAt,
     this.doneAt,
     this.linkPreview = const {},
@@ -34,7 +33,6 @@ class TripActivity {
 
   /// Whether participants consider this outing done.
   final bool done;
-  final bool isLocked;
   final DateTime? plannedAt;
   final DateTime? doneAt;
 
@@ -64,12 +62,6 @@ class TripActivity {
         : doneRaw is String
             ? doneRaw.toLowerCase() == 'true'
             : false;
-    final lockedRaw = data['isLocked'];
-    final isLocked = lockedRaw is bool
-        ? lockedRaw
-        : lockedRaw is String
-            ? lockedRaw.toLowerCase() == 'true'
-            : false;
     final doneAtRaw = data['doneAt'];
     final doneAt = switch (doneAtRaw) {
       Timestamp ts => ts.toDate(),
@@ -93,7 +85,6 @@ class TripActivity {
       createdBy: (data['createdBy'] as String?) ?? '',
       createdAt: createdAt,
       done: done,
-      isLocked: isLocked,
       plannedAt: plannedAt,
       doneAt: done ? doneAt : null,
       linkPreview: _previewFromFirestore(data['linkPreview']),

--- a/lib/features/activities/presentation/trip_activities_page.dart
+++ b/lib/features/activities/presentation/trip_activities_page.dart
@@ -819,7 +819,6 @@ class _AddActivitySheetState extends ConsumerState<_AddActivitySheet> {
   late final TextEditingController _addressController;
   late final TextEditingController _commentsController;
   TripActivityCategory _category = TripActivityCategory.visit;
-  bool _isLocked = false;
   bool _saving = false;
 
   @override
@@ -867,7 +866,6 @@ class _AddActivitySheetState extends ConsumerState<_AddActivitySheet> {
             linkUrl: _linkController.text,
             address: _addressController.text,
             freeComments: _commentsController.text,
-            isLocked: _isLocked,
           );
       if (!mounted) return;
       widget.onSaved();
@@ -959,17 +957,6 @@ class _AddActivitySheetState extends ConsumerState<_AddActivitySheet> {
               maxLines: 3,
             ),
             const SizedBox(height: 12),
-            SwitchListTile(
-              value: _isLocked,
-              onChanged:
-                  _saving ? null : (value) => setState(() => _isLocked = value),
-              title: Text(AppLocalizations.of(context)!.activitiesLocked),
-              subtitle: Text(
-                AppLocalizations.of(context)!.activitiesLockedHint,
-              ),
-              contentPadding: EdgeInsets.zero,
-            ),
-            const SizedBox(height: 8),
             TextFormField(
               controller: _commentsController,
               textInputAction: TextInputAction.done,

--- a/lib/features/activities/presentation/trip_activity_detail_page.dart
+++ b/lib/features/activities/presentation/trip_activity_detail_page.dart
@@ -57,7 +57,6 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
   late final TextEditingController _addressController;
   late final TextEditingController _commentsController;
   TripActivityCategory _category = TripActivityCategory.visit;
-  bool _isLocked = false;
   bool _editing = false;
   bool _saving = false;
   bool _deleting = false;
@@ -88,7 +87,6 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
         prev.address == next.address &&
         prev.freeComments == next.freeComments &&
         prev.category == next.category &&
-        prev.isLocked == next.isLocked &&
         prev.done == next.done;
   }
 
@@ -101,7 +99,6 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
     _addressController.text = activity.address;
     _commentsController.text = activity.freeComments;
     _category = activity.category;
-    _isLocked = activity.isLocked;
   }
 
   void _applyActivity(TripActivity activity) {
@@ -110,7 +107,6 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
     _addressController.text = activity.address;
     _commentsController.text = activity.freeComments;
     _category = activity.category;
-    _isLocked = activity.isLocked;
     _lastSyncedActivity = activity;
   }
 
@@ -143,7 +139,6 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
             linkUrl: _linkController.text,
             address: _addressController.text,
             freeComments: _commentsController.text,
-            isLocked: _isLocked,
           );
       if (!mounted) return;
       setState(() => _editing = false);
@@ -341,9 +336,6 @@ class _TripActivityDetailPageState extends ConsumerState<TripActivityDetailPage>
                   onCategoryChanged: _saving
                       ? null
                       : (c) => setState(() => _category = c),
-                  isLocked: _isLocked,
-                  onLockChanged:
-                      _saving ? null : (v) => setState(() => _isLocked = v),
                   activity: activity,
                   validateOptionalUrl: _validateOptionalUrl,
                 )
@@ -597,8 +589,6 @@ class _EditBody extends StatefulWidget {
     required this.commentsController,
     required this.category,
     required this.onCategoryChanged,
-    required this.isLocked,
-    required this.onLockChanged,
     required this.activity,
     required this.validateOptionalUrl,
   });
@@ -610,8 +600,6 @@ class _EditBody extends StatefulWidget {
   final TextEditingController commentsController;
   final TripActivityCategory category;
   final void Function(TripActivityCategory)? onCategoryChanged;
-  final bool isLocked;
-  final void Function(bool)? onLockChanged;
   final TripActivity activity;
   final String? Function(String?) validateOptionalUrl;
 
@@ -720,16 +708,6 @@ class _EditBodyState extends State<_EditBody> {
             ),
             minLines: 1,
             maxLines: 3,
-          ),
-          const SizedBox(height: 8),
-          SwitchListTile(
-            value: widget.isLocked,
-            onChanged: widget.onLockChanged,
-            title: Text(AppLocalizations.of(context)!.activitiesLocked),
-            subtitle: Text(
-              AppLocalizations.of(context)!.activitiesLockedHint,
-            ),
-            contentPadding: EdgeInsets.zero,
           ),
           const SizedBox(height: 12),
           TextFormField(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -511,8 +511,6 @@
   "activitiesLink": "Link (website, tickets, ...)",
   "activitiesAddress": "Location address (route from trip)",
   "activitiesAddressHint": "Used to calculate driving distance and duration",
-  "activitiesLocked": "Locked activity",
-  "activitiesLockedHint": "If enabled, only admins can edit this activity.",
   "activitiesComments": "Comments",
   "linkInvalidExample": "Invalid link (example: https://...)",
   "shoppingDeleteCheckedTitle": "Delete checked items?",

--- a/lib/l10n/app_en_US.arb
+++ b/lib/l10n/app_en_US.arb
@@ -511,8 +511,6 @@
   "activitiesLink": "Link (website, tickets, ...)",
   "activitiesAddress": "Location address (route from trip)",
   "activitiesAddressHint": "Used to calculate driving distance and duration",
-  "activitiesLocked": "Locked activity",
-  "activitiesLockedHint": "If enabled, only admins can edit this activity.",
   "activitiesComments": "Comments",
   "linkInvalidExample": "Invalid link (example: https://...)",
   "shoppingDeleteCheckedTitle": "Delete checked items?",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -511,8 +511,6 @@
   "activitiesLink": "Lien (site, billetterie, ...)",
   "activitiesAddress": "Adresse du lieu (trajet depuis le voyage)",
   "activitiesAddressHint": "Pour calculer distance et durée en voiture",
-  "activitiesLocked": "Activité verrouillée",
-  "activitiesLockedHint": "Si activée, seuls les admins peuvent modifier cette activité.",
   "activitiesComments": "Commentaires",
   "linkInvalidExample": "Lien invalide (ex: https://...)",
   "shoppingDeleteCheckedTitle": "Supprimer les éléments cochés ?",

--- a/lib/l10n/app_fr_FR.arb
+++ b/lib/l10n/app_fr_FR.arb
@@ -511,8 +511,6 @@
   "activitiesLink": "Lien (site, billetterie, ...)",
   "activitiesAddress": "Adresse du lieu (trajet depuis le voyage)",
   "activitiesAddressHint": "Pour calculer distance et durée en voiture",
-  "activitiesLocked": "Activité verrouillée",
-  "activitiesLockedHint": "Si activée, seuls les admins peuvent modifier cette activité.",
   "activitiesComments": "Commentaires",
   "linkInvalidExample": "Lien invalide (ex: https://...)",
   "shoppingDeleteCheckedTitle": "Supprimer les éléments cochés ?",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2231,18 +2231,6 @@ abstract class AppLocalizations {
   /// **'Pour calculer distance et durée en voiture'**
   String get activitiesAddressHint;
 
-  /// No description provided for @activitiesLocked.
-  ///
-  /// In fr, this message translates to:
-  /// **'Activité verrouillée'**
-  String get activitiesLocked;
-
-  /// No description provided for @activitiesLockedHint.
-  ///
-  /// In fr, this message translates to:
-  /// **'Si activée, seuls les admins peuvent modifier cette activité.'**
-  String get activitiesLockedHint;
-
   /// No description provided for @activitiesComments.
   ///
   /// In fr, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1199,13 +1199,6 @@ class AppLocalizationsEn extends AppLocalizations {
       'Used to calculate driving distance and duration';
 
   @override
-  String get activitiesLocked => 'Locked activity';
-
-  @override
-  String get activitiesLockedHint =>
-      'If enabled, only admins can edit this activity.';
-
-  @override
   String get activitiesComments => 'Comments';
 
   @override
@@ -3038,13 +3031,6 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
   @override
   String get activitiesAddressHint =>
       'Used to calculate driving distance and duration';
-
-  @override
-  String get activitiesLocked => 'Locked activity';
-
-  @override
-  String get activitiesLockedHint =>
-      'If enabled, only admins can edit this activity.';
 
   @override
   String get activitiesComments => 'Comments';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1211,13 +1211,6 @@ class AppLocalizationsFr extends AppLocalizations {
       'Pour calculer distance et durée en voiture';
 
   @override
-  String get activitiesLocked => 'Activité verrouillée';
-
-  @override
-  String get activitiesLockedHint =>
-      'Si activée, seuls les admins peuvent modifier cette activité.';
-
-  @override
   String get activitiesComments => 'Commentaires';
 
   @override
@@ -3064,13 +3057,6 @@ class AppLocalizationsFrFr extends AppLocalizationsFr {
   @override
   String get activitiesAddressHint =>
       'Pour calculer distance et durée en voiture';
-
-  @override
-  String get activitiesLocked => 'Activité verrouillée';
-
-  @override
-  String get activitiesLockedHint =>
-      'Si activée, seuls les admins peuvent modifier cette activité.';
 
   @override
   String get activitiesComments => 'Commentaires';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the `isLocked` field from trip activity domain and repository write payloads
- remove all activity lock enforcement logic from repository mutations and Firestore rules
- remove the lock toggle from activity creation and edit UIs
- delete now-unused localization keys related to locked activities across ARB and generated localization files

## Validation
- verified by code search that no `isLocked` / activity lock references remain in the repository
- could not run `flutter analyze` in this environment because Flutter/Dart CLI is unavailable (`flutter: command not found`, `dart: command not found`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3351940a-bd4c-4567-be46-ddeb5efbe2fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3351940a-bd4c-4567-be46-ddeb5efbe2fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

