### PR TITLE
Fix FAB overlap with legal footer on trips page

### DIFF
--- a/lib/features/trips/presentation/trips_page.dart
+++ b/lib/features/trips/presentation/trips_page.dart
@@ -25,6 +25,7 @@ enum _TripTimelineCategory { past, ongoing, upcoming }
 class _TripsPageState extends ConsumerState<TripsPage>
     with SingleTickerProviderStateMixin {
   static const double _legalLinkFontSize = 12;
+  static const double _floatingActionButtonsBottomOffset = 34;
   late final TabController _tabController;
   bool _didHandleAutoOpenCurrentTrip = false;
 
@@ -58,24 +59,29 @@ class _TripsPageState extends ConsumerState<TripsPage>
           AccountAppBarActions(),
         ],
       ),
-      floatingActionButton: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          FloatingActionButton(
-            heroTag: 'trips_join_invite',
-            tooltip: l10n.tripsJoinWithInviteTooltip,
-            onPressed: () => _openJoinByInviteCodeDialog(context),
-            child: const Icon(Icons.vpn_key_outlined),
-          ),
-          const SizedBox(height: 16),
-          FloatingActionButton(
-            heroTag: 'trips_create',
-            tooltip: l10n.tripsNewTripTooltip,
-            onPressed: () => _openCreateTripDialog(context, ref),
-            child: const Icon(Icons.add),
-          ),
-        ],
+      floatingActionButton: Padding(
+        padding: const EdgeInsets.only(
+          bottom: _floatingActionButtonsBottomOffset,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            FloatingActionButton(
+              heroTag: 'trips_join_invite',
+              tooltip: l10n.tripsJoinWithInviteTooltip,
+              onPressed: () => _openJoinByInviteCodeDialog(context),
+              child: const Icon(Icons.vpn_key_outlined),
+            ),
+            const SizedBox(height: 16),
+            FloatingActionButton(
+              heroTag: 'trips_create',
+              tooltip: l10n.tripsNewTripTooltip,
+              onPressed: () => _openCreateTripDialog(context, ref),
+              child: const Icon(Icons.add),
+            ),
+          ],
+        ),
       ),
       body: Stack(
         children: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- raises the two floating action buttons on the trips list page so they no longer overlap the legal/about/copyright footer row
- keeps the existing FAB behavior and layout intact while applying a dedicated bottom offset

## Why
- preserves footer readability and tap accessibility on small viewports where the previous FAB position partially covered the legal row
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-211aaee5-f442-4e96-b8e2-456e002ea4fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-211aaee5-f442-4e96-b8e2-456e002ea4fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

