### PR TITLE
feat(auth): gate Android PWA sign-in behind APK install card

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "PowerShell(git add web/.well-known/assetlinks.json)",
+      "Bash(flutter analyze *)",
+      "PowerShell(git add lib/app/router.dart lib/features/auth/sign_in_page.dart)",
+      "PowerShell(git add CLAUDE.md GUIDELINES.md .cursor/rules/planerz-guidelines.mdc)",
+      "PowerShell(git add android/app/src/main/AndroidManifest.xml lib/features/auth/data/auth_repository.dart)",
+      "Bash(flutter gen-l10n *)",
+      "Bash(flutter pub *)"
+    ]
+  }
+}

--- a/lib/core/external_links.dart
+++ b/lib/core/external_links.dart
@@ -1,3 +1,3 @@
 final Uri appPreviewApkDownloadUri = Uri.parse(
-  'https://github.com/CenturySpine/Planzers/releases/latest/download/planerz-preview.apk',
+  'https://github.com/CenturySpine/Planzers/releases/latest/download/centuryspine.planerz.apk',
 );

--- a/lib/core/external_links.dart
+++ b/lib/core/external_links.dart
@@ -1,0 +1,3 @@
+final Uri appPreviewApkDownloadUri = Uri.parse(
+  'https://github.com/CenturySpine/Planzers/releases/latest/download/planerz-preview.apk',
+);

--- a/lib/core/platform/android_pwa_mode_detector.dart
+++ b/lib/core/platform/android_pwa_mode_detector.dart
@@ -1,0 +1,5 @@
+import 'android_pwa_mode_detector_stub.dart'
+    if (dart.library.html) 'android_pwa_mode_detector_web.dart'
+    as detector;
+
+bool isAndroidPwaMode() => detector.isAndroidPwaMode();

--- a/lib/core/platform/android_pwa_mode_detector_stub.dart
+++ b/lib/core/platform/android_pwa_mode_detector_stub.dart
@@ -1,0 +1,1 @@
+bool isAndroidPwaMode() => false;

--- a/lib/core/platform/android_pwa_mode_detector_web.dart
+++ b/lib/core/platform/android_pwa_mode_detector_web.dart
@@ -1,0 +1,20 @@
+// ignore_for_file: avoid_web_libraries_in_flutter, deprecated_member_use
+
+import 'dart:html' as html;
+
+bool isAndroidPwaMode() {
+  final userAgent = html.window.navigator.userAgent.toLowerCase();
+  final isAndroidDevice = userAgent.contains('android');
+  if (!isAndroidDevice) {
+    return false;
+  }
+
+  final standalone =
+      html.window.matchMedia('(display-mode: standalone)').matches;
+  final minimalUi =
+      html.window.matchMedia('(display-mode: minimal-ui)').matches;
+  final fullscreen =
+      html.window.matchMedia('(display-mode: fullscreen)').matches;
+
+  return standalone || minimalUi || fullscreen;
+}

--- a/lib/features/account/presentation/account_menu_button.dart
+++ b/lib/features/account/presentation/account_menu_button.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:planerz/core/external_links.dart';
 import 'package:planerz/core/notifications/notification_center_repository.dart';
 import 'package:planerz/core/push/fcm_token_sync.dart';
 import 'package:planerz/features/account/data/account_repository.dart';
@@ -14,10 +15,6 @@ import 'package:url_launcher/url_launcher.dart';
 class AccountMenuButton extends ConsumerWidget {
   const AccountMenuButton({super.key});
 
-  static final Uri _apkDownloadUri = Uri.parse(
-    'https://github.com/CenturySpine/Planzers/releases/latest/download/planerz-preview.apk',
-  );
-
   Future<void> _goToAccount(BuildContext context) async {
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
     context.push('/account');
@@ -26,7 +23,7 @@ class AccountMenuButton extends ConsumerWidget {
   Future<void> _downloadApk(BuildContext context) async {
     final l10n = AppLocalizations.of(context)!;
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
-    final ok = await launchUrl(_apkDownloadUri);
+    final ok = await launchUrl(appPreviewApkDownloadUri);
     if (!ok && context.mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l10n.linkOpenImpossible)),

--- a/lib/features/account/presentation/account_menu_button.dart
+++ b/lib/features/account/presentation/account_menu_button.dart
@@ -1,11 +1,11 @@
 ﻿import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:planerz/core/external_links.dart';
 import 'package:planerz/core/notifications/notification_center_repository.dart';
+import 'package:planerz/core/platform/android_pwa_mode_detector.dart';
 import 'package:planerz/core/push/fcm_token_sync.dart';
 import 'package:planerz/features/account/data/account_repository.dart';
 import 'package:planerz/features/auth/data/user_display_label.dart';
@@ -70,6 +70,7 @@ class AccountMenuButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context)!;
+    final showDownloadApkAction = isAndroidPwaMode();
     final user = FirebaseAuth.instance.currentUser;
     final email = (user?.email ?? '').trim();
     final displayLabel = (user?.displayName ?? '').trim().isNotEmpty
@@ -133,7 +134,7 @@ class AccountMenuButton extends ConsumerWidget {
           value: 'account',
           child: Text(l10n.accountTitle),
         ),
-        if (kIsWeb)
+        if (showDownloadApkAction)
           PopupMenuItem<String>(
             value: 'download_apk',
             child: Text(l10n.accountDownloadApk),

--- a/lib/features/auth/sign_in_page.dart
+++ b/lib/features/auth/sign_in_page.dart
@@ -365,68 +365,130 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.stretch,
                                 children: [
-                                  OutlinedButton(
-                                    onPressed:
-                                        _isLoading ? null : _signInWithGoogle,
-                                    style: OutlinedButton.styleFrom(
-                                      backgroundColor: Colors.white,
-                                      foregroundColor: _googleSignInText,
-                                      disabledForegroundColor: _googleSignInText
-                                          .withValues(alpha: 0.55),
-                                      side: const BorderSide(
-                                        color: _googleSignInBorder,
-                                        width: 1,
+                                  if (_showAndroidPwaInstallOverlay)
+                                    _buildAndroidPwaInstallGate(l10n)
+                                  else ...[
+                                    OutlinedButton(
+                                      onPressed:
+                                          _isLoading ? null : _signInWithGoogle,
+                                      style: OutlinedButton.styleFrom(
+                                        backgroundColor: Colors.white,
+                                        foregroundColor: _googleSignInText,
+                                        disabledForegroundColor:
+                                            _googleSignInText.withValues(
+                                              alpha: 0.55,
+                                            ),
+                                        side: const BorderSide(
+                                          color: _googleSignInBorder,
+                                          width: 1,
+                                        ),
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 28,
+                                          vertical: 14,
+                                        ),
+                                        minimumSize: const Size.fromHeight(50),
+                                        shape: RoundedRectangleBorder(
+                                          borderRadius: BorderRadius.circular(10),
+                                        ),
                                       ),
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 28,
-                                        vertical: 14,
-                                      ),
-                                      minimumSize: const Size.fromHeight(50),
-                                      shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(10),
-                                      ),
+                                      child: _isLoading
+                                          ? Row(
+                                              mainAxisAlignment:
+                                                  MainAxisAlignment.center,
+                                              mainAxisSize: MainAxisSize.min,
+                                              children: [
+                                                SizedBox(
+                                                  width: 20,
+                                                  height: 20,
+                                                  child:
+                                                      CircularProgressIndicator(
+                                                    strokeWidth: 2,
+                                                    color: _googleSignInText
+                                                        .withValues(alpha: 0.7),
+                                                  ),
+                                                ),
+                                                const SizedBox(width: 12),
+                                                Text(
+                                                  l10n.signInLoading,
+                                                  style: TextStyle(
+                                                    fontSize: 15,
+                                                    fontWeight: FontWeight.w500,
+                                                    color: _googleSignInText
+                                                        .withValues(alpha: 0.7),
+                                                  ),
+                                                ),
+                                              ],
+                                            )
+                                          : Row(
+                                              mainAxisAlignment:
+                                                  MainAxisAlignment.center,
+                                              mainAxisSize: MainAxisSize.min,
+                                              children: [
+                                                SvgPicture.asset(
+                                                  'assets/images/google_g.svg',
+                                                  width: 20,
+                                                  height: 20,
+                                                ),
+                                                const SizedBox(width: 12),
+                                                Text(
+                                                  l10n.signInContinueWithGoogle,
+                                                  style: TextStyle(
+                                                    fontSize: 15,
+                                                    fontWeight: FontWeight.w500,
+                                                    color: _googleSignInText,
+                                                    letterSpacing: 0.15,
+                                                  ),
+                                                ),
+                                              ],
+                                            ),
                                     ),
-                                    child: _isLoading
-                                        ? Row(
+                                    const SizedBox(height: 10),
+                                    Stack(
+                                      clipBehavior: Clip.none,
+                                      children: [
+                                        OutlinedButton(
+                                          onPressed: _isLoading
+                                              ? null
+                                              : () => context.push(
+                                                    EmailLinkSignInPage
+                                                        .routePath,
+                                                  ),
+                                          style: OutlinedButton.styleFrom(
+                                            backgroundColor: Colors.white,
+                                            foregroundColor: _googleSignInText,
+                                            disabledForegroundColor:
+                                                _googleSignInText.withValues(
+                                                  alpha: 0.55,
+                                                ),
+                                            side: const BorderSide(
+                                              color: _googleSignInBorder,
+                                              width: 1,
+                                            ),
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: 28,
+                                              vertical: 14,
+                                            ),
+                                            minimumSize:
+                                                const Size.fromHeight(50),
+                                            shape: RoundedRectangleBorder(
+                                              borderRadius:
+                                                  BorderRadius.circular(10),
+                                            ),
+                                          ),
+                                          child: Row(
                                             mainAxisAlignment:
                                                 MainAxisAlignment.center,
                                             mainAxisSize: MainAxisSize.min,
                                             children: [
-                                              SizedBox(
-                                                width: 20,
-                                                height: 20,
-                                                child:
-                                                    CircularProgressIndicator(
-                                                  strokeWidth: 2,
-                                                  color: _googleSignInText
-                                                      .withValues(alpha: 0.7),
-                                                ),
+                                              Icon(
+                                                Icons.mail_outline,
+                                                size: 20,
+                                                color: _googleSignInText,
                                               ),
                                               const SizedBox(width: 12),
                                               Text(
-                                                l10n.signInLoading,
-                                                style: TextStyle(
-                                                  fontSize: 15,
-                                                  fontWeight: FontWeight.w500,
-                                                  color: _googleSignInText
-                                                      .withValues(alpha: 0.7),
-                                                ),
-                                              ),
-                                            ],
-                                          )
-                                        : Row(
-                                            mainAxisAlignment:
-                                                MainAxisAlignment.center,
-                                            mainAxisSize: MainAxisSize.min,
-                                            children: [
-                                              SvgPicture.asset(
-                                                'assets/images/google_g.svg',
-                                                width: 20,
-                                                height: 20,
-                                              ),
-                                              const SizedBox(width: 12),
-                                              Text(
-                                                l10n.signInContinueWithGoogle,
+                                                l10n
+                                                    .signInContinueWithEmailLink,
                                                 style: TextStyle(
                                                   fontSize: 15,
                                                   fontWeight: FontWeight.w500,
@@ -436,146 +498,93 @@ class _SignInPageState extends ConsumerState<SignInPage> {
                                               ),
                                             ],
                                           ),
-                                  ),
-                                  const SizedBox(height: 10),
-                                  Stack(
-                                    clipBehavior: Clip.none,
-                                    children: [
-                                      OutlinedButton(
-                                        onPressed: _isLoading
-                                            ? null
-                                            : () => context.push(
-                                                  EmailLinkSignInPage.routePath,
+                                        ),
+                                        Positioned(
+                                          top: -6,
+                                          right: -6,
+                                          child: _buildAuthBetaPill(l10n),
+                                        ),
+                                      ],
+                                    ),
+                                    const SizedBox(height: 10),
+                                    Stack(
+                                      clipBehavior: Clip.none,
+                                      children: [
+                                        OutlinedButton(
+                                          onPressed: _isLoading
+                                              ? null
+                                              : () {
+                                                  final redirect =
+                                                      widget.redirectAfterSignIn;
+                                                  final route = (redirect !=
+                                                              null &&
+                                                          redirect
+                                                              .trim()
+                                                              .isNotEmpty)
+                                                      ? Uri(
+                                                          path: PhoneSignInPage
+                                                              .routePath,
+                                                          queryParameters: {
+                                                            'redirect': redirect,
+                                                          },
+                                                        ).toString()
+                                                      : PhoneSignInPage
+                                                          .routePath;
+                                                  context.push(route);
+                                                },
+                                          style: OutlinedButton.styleFrom(
+                                            backgroundColor: Colors.white,
+                                            foregroundColor: _googleSignInText,
+                                            disabledForegroundColor:
+                                                _googleSignInText.withValues(
+                                                  alpha: 0.55,
                                                 ),
-                                        style: OutlinedButton.styleFrom(
-                                          backgroundColor: Colors.white,
-                                          foregroundColor: _googleSignInText,
-                                          disabledForegroundColor:
-                                              _googleSignInText.withValues(
-                                                alpha: 0.55,
-                                              ),
-                                          side: const BorderSide(
-                                            color: _googleSignInBorder,
-                                            width: 1,
-                                          ),
-                                          padding: const EdgeInsets.symmetric(
-                                            horizontal: 28,
-                                            vertical: 14,
-                                          ),
-                                          minimumSize:
-                                              const Size.fromHeight(50),
-                                          shape: RoundedRectangleBorder(
-                                            borderRadius:
-                                                BorderRadius.circular(10),
-                                          ),
-                                        ),
-                                        child: Row(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.center,
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: [
-                                            Icon(
-                                              Icons.mail_outline,
-                                              size: 20,
-                                              color: _googleSignInText,
+                                            side: const BorderSide(
+                                              color: _googleSignInBorder,
+                                              width: 1,
                                             ),
-                                            const SizedBox(width: 12),
-                                            Text(
-                                              l10n.signInContinueWithEmailLink,
-                                              style: TextStyle(
-                                                fontSize: 15,
-                                                fontWeight: FontWeight.w500,
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: 28,
+                                              vertical: 14,
+                                            ),
+                                            minimumSize:
+                                                const Size.fromHeight(50),
+                                            shape: RoundedRectangleBorder(
+                                              borderRadius:
+                                                  BorderRadius.circular(10),
+                                            ),
+                                          ),
+                                          child: Row(
+                                            mainAxisAlignment:
+                                                MainAxisAlignment.center,
+                                            mainAxisSize: MainAxisSize.min,
+                                            children: [
+                                              Icon(
+                                                Icons.phone_outlined,
+                                                size: 20,
                                                 color: _googleSignInText,
-                                                letterSpacing: 0.15,
                                               ),
-                                            ),
-                                          ],
-                                        ),
-                                      ),
-                                      Positioned(
-                                        top: -6,
-                                        right: -6,
-                                        child: _buildAuthBetaPill(l10n),
-                                      ),
-                                    ],
-                                  ),
-                                  const SizedBox(height: 10),
-                                  Stack(
-                                    clipBehavior: Clip.none,
-                                    children: [
-                                      OutlinedButton(
-                                        onPressed: _isLoading
-                                            ? null
-                                            : () {
-                                                final redirect =
-                                                    widget.redirectAfterSignIn;
-                                                final route = (redirect !=
-                                                            null &&
-                                                        redirect
-                                                            .trim()
-                                                            .isNotEmpty)
-                                                    ? Uri(
-                                                        path: PhoneSignInPage
-                                                            .routePath,
-                                                        queryParameters: {
-                                                          'redirect': redirect,
-                                                        },
-                                                      ).toString()
-                                                    : PhoneSignInPage.routePath;
-                                                context.push(route);
-                                              },
-                                        style: OutlinedButton.styleFrom(
-                                          backgroundColor: Colors.white,
-                                          foregroundColor: _googleSignInText,
-                                          disabledForegroundColor:
-                                              _googleSignInText.withValues(
-                                                alpha: 0.55,
+                                              const SizedBox(width: 12),
+                                              Text(
+                                                l10n.signInContinueWithPhone,
+                                                style: TextStyle(
+                                                  fontSize: 15,
+                                                  fontWeight: FontWeight.w500,
+                                                  color: _googleSignInText,
+                                                  letterSpacing: 0.15,
+                                                ),
                                               ),
-                                          side: const BorderSide(
-                                            color: _googleSignInBorder,
-                                            width: 1,
-                                          ),
-                                          padding: const EdgeInsets.symmetric(
-                                            horizontal: 28,
-                                            vertical: 14,
-                                          ),
-                                          minimumSize:
-                                              const Size.fromHeight(50),
-                                          shape: RoundedRectangleBorder(
-                                            borderRadius:
-                                                BorderRadius.circular(10),
+                                            ],
                                           ),
                                         ),
-                                        child: Row(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.center,
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: [
-                                            Icon(
-                                              Icons.phone_outlined,
-                                              size: 20,
-                                              color: _googleSignInText,
-                                            ),
-                                            const SizedBox(width: 12),
-                                            Text(
-                                              l10n.signInContinueWithPhone,
-                                              style: TextStyle(
-                                                fontSize: 15,
-                                                fontWeight: FontWeight.w500,
-                                                color: _googleSignInText,
-                                                letterSpacing: 0.15,
-                                              ),
-                                            ),
-                                          ],
+                                        Positioned(
+                                          top: -6,
+                                          right: -6,
+                                          child: _buildAuthBetaPill(l10n),
                                         ),
-                                      ),
-                                      Positioned(
-                                        top: -6,
-                                        right: -6,
-                                        child: _buildAuthBetaPill(l10n),
-                                      ),
-                                    ],
-                                  ),
+                                      ],
+                                    ),
+                                  ],
                                 ],
                               ),
                             ),
@@ -716,72 +725,58 @@ class _SignInPageState extends ConsumerState<SignInPage> {
               ),
             ),
           ),
-          if (_showAndroidPwaInstallOverlay)
-            SafeArea(
-              child: Align(
-                alignment: Alignment.topCenter,
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-                  child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 460),
-                    child: Material(
-                      color: Colors.transparent,
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.surface,
-                          borderRadius: BorderRadius.circular(14),
-                          border: Border.all(
-                            color: Theme.of(context).colorScheme.outlineVariant,
-                          ),
-                          boxShadow: const [
-                            BoxShadow(
-                              blurRadius: 12,
-                              offset: Offset(0, 4),
-                              color: Color(0x22000000),
-                            ),
-                          ],
-                        ),
-                        child: Padding(
-                          padding: const EdgeInsets.fromLTRB(14, 10, 10, 10),
-                          child: Row(
-                            children: [
-                              FaIcon(
-                                FontAwesomeIcons.github,
-                                size: 18,
-                                color: Theme.of(context).colorScheme.onSurface,
-                              ),
-                              const SizedBox(width: 10),
-                              Expanded(
-                                child: Text(
-                                  l10n.signInAndroidPwaInstallOverlayMessage,
-                                  style: TextStyle(
-                                    fontSize: 13,
-                                    color: Theme.of(context).colorScheme.onSurface,
-                                  ),
-                                ),
-                              ),
-                              IconButton(
-                                onPressed: _openAndroidApkDownload,
-                                tooltip: l10n.accountDownloadApk,
-                                visualDensity: VisualDensity.compact,
-                                icon: const Icon(Icons.download_outlined),
-                              ),
-                              IconButton(
-                                onPressed: _dismissAndroidPwaInstallOverlay,
-                                tooltip: l10n.commonClose,
-                                visualDensity: VisualDensity.compact,
-                                icon: const Icon(Icons.close),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAndroidPwaInstallGate(AppLocalizations l10n) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+        boxShadow: const [
+          BoxShadow(
+            blurRadius: 12,
+            offset: Offset(0, 4),
+            color: Color(0x22000000),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(14, 10, 10, 10),
+        child: Row(
+          children: [
+            FaIcon(
+              FontAwesomeIcons.github,
+              size: 18,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                l10n.signInAndroidPwaInstallOverlayMessage,
+                style: TextStyle(
+                  fontSize: 13,
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
               ),
             ),
-        ],
+            IconButton(
+              onPressed: _openAndroidApkDownload,
+              tooltip: l10n.accountDownloadApk,
+              visualDensity: VisualDensity.compact,
+              icon: const Icon(Icons.download_outlined),
+            ),
+            IconButton(
+              onPressed: _dismissAndroidPwaInstallOverlay,
+              tooltip: l10n.commonClose,
+              visualDensity: VisualDensity.compact,
+              icon: const Icon(Icons.close),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/auth/sign_in_page.dart
+++ b/lib/features/auth/sign_in_page.dart
@@ -1,19 +1,23 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
+import 'package:planerz/core/external_links.dart';
 import 'package:planerz/core/intl/app_language.dart';
 import 'package:planerz/core/intl/app_locale_provider.dart';
+import 'package:planerz/core/platform/android_pwa_mode_detector.dart';
 import 'package:planerz/features/about/presentation/about_page.dart';
 import 'package:planerz/features/auth/data/auth_repository.dart';
 import 'package:planerz/features/auth/email_link_sign_in_page.dart';
 import 'package:planerz/features/auth/phone_sign_in_page.dart';
 import 'package:planerz/features/legal/presentation/legal_information_page.dart';
 import 'package:planerz/l10n/app_localizations.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 const Color _googleSignInBorder = Color(0xFFDADCE0);
 const Color _googleSignInText = Color(0xFF3C4043);
@@ -34,11 +38,13 @@ class SignInPage extends ConsumerStatefulWidget {
 
 class _SignInPageState extends ConsumerState<SignInPage> {
   bool _isLoading = false;
+  bool _showAndroidPwaInstallOverlay = false;
   static const double _legalLinkFontSize = 12;
   static const double _footerReservedHeight = 32;
   static const int _animatedLabelCount = 3;
   static const Duration _labelDisplayDuration = Duration(seconds: 3);
   static const Duration _labelTransitionDuration = Duration(milliseconds: 420);
+  static bool _androidPwaInstallOverlayDismissedForSession = false;
 
   int _animatedLabelIndex = 0;
   Timer? _subtitleTimer;
@@ -47,6 +53,8 @@ class _SignInPageState extends ConsumerState<SignInPage> {
   void initState() {
     super.initState();
     _scheduleSubtitleStep();
+    _showAndroidPwaInstallOverlay =
+        !_androidPwaInstallOverlayDismissedForSession && isAndroidPwaMode();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       unawaited(_completeEmailLinkSignInIfNeeded());
     });
@@ -204,6 +212,21 @@ class _SignInPageState extends ConsumerState<SignInPage> {
 
   Future<void> _setLanguage(AppLanguage language) async {
     await ref.read(appLocalePreferenceProvider.notifier).setLanguage(language);
+  }
+
+  Future<void> _openAndroidApkDownload() async {
+    final l10n = AppLocalizations.of(context)!;
+    final ok = await launchUrl(appPreviewApkDownloadUri);
+    if (!ok && mounted) {
+      _showInfoSnackBar(l10n.linkOpenImpossible);
+    }
+  }
+
+  void _dismissAndroidPwaInstallOverlay() {
+    setState(() {
+      _androidPwaInstallOverlayDismissedForSession = true;
+      _showAndroidPwaInstallOverlay = false;
+    });
   }
 
   @override
@@ -693,6 +716,71 @@ class _SignInPageState extends ConsumerState<SignInPage> {
               ),
             ),
           ),
+          if (_showAndroidPwaInstallOverlay)
+            SafeArea(
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 460),
+                    child: Material(
+                      color: Colors.transparent,
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.surface,
+                          borderRadius: BorderRadius.circular(14),
+                          border: Border.all(
+                            color: Theme.of(context).colorScheme.outlineVariant,
+                          ),
+                          boxShadow: const [
+                            BoxShadow(
+                              blurRadius: 12,
+                              offset: Offset(0, 4),
+                              color: Color(0x22000000),
+                            ),
+                          ],
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(14, 10, 10, 10),
+                          child: Row(
+                            children: [
+                              FaIcon(
+                                FontAwesomeIcons.github,
+                                size: 18,
+                                color: Theme.of(context).colorScheme.onSurface,
+                              ),
+                              const SizedBox(width: 10),
+                              Expanded(
+                                child: Text(
+                                  l10n.signInAndroidPwaInstallOverlayMessage,
+                                  style: TextStyle(
+                                    fontSize: 13,
+                                    color: Theme.of(context).colorScheme.onSurface,
+                                  ),
+                                ),
+                              ),
+                              IconButton(
+                                onPressed: _openAndroidApkDownload,
+                                tooltip: l10n.accountDownloadApk,
+                                visualDensity: VisualDensity.compact,
+                                icon: const Icon(Icons.download_outlined),
+                              ),
+                              IconButton(
+                                onPressed: _dismissAndroidPwaInstallOverlay,
+                                tooltip: l10n.commonClose,
+                                visualDensity: VisualDensity.compact,
+                                icon: const Icon(Icons.close),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
         ],
       ),
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -67,6 +67,7 @@
   "signInPhoneChangeNumber": "Change number",
   "signInPhoneResendCode": "Resend code",
   "signInAuthBetaPill": "BETA",
+  "signInAndroidPwaInstallOverlayMessage": "For a better Android experience, install the app from GitHub.",
   "accountTitle": "My account",
   "accountCropProfilePhotoTitle": "Crop profile photo",
   "accountPhotoUpdated": "Profile photo updated",

--- a/lib/l10n/app_en_US.arb
+++ b/lib/l10n/app_en_US.arb
@@ -67,6 +67,7 @@
   "signInPhoneChangeNumber": "Change number",
   "signInPhoneResendCode": "Resend code",
   "signInAuthBetaPill": "BETA",
+  "signInAndroidPwaInstallOverlayMessage": "For a better Android experience, install the app from GitHub.",
   "accountTitle": "My account",
   "accountCropProfilePhotoTitle": "Crop profile photo",
   "accountPhotoUpdated": "Profile photo updated",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -67,6 +67,7 @@
   "signInPhoneChangeNumber": "Changer de numéro",
   "signInPhoneResendCode": "Renvoyer le code",
   "signInAuthBetaPill": "BETA",
+  "signInAndroidPwaInstallOverlayMessage": "Pour une meilleure expérience sur Android, installe l'application depuis GitHub.",
   "accountTitle": "Mon compte",
   "accountCropProfilePhotoTitle": "Recadrer la photo de profil",
   "accountPhotoUpdated": "Photo de profil mise à jour",

--- a/lib/l10n/app_fr_FR.arb
+++ b/lib/l10n/app_fr_FR.arb
@@ -67,6 +67,7 @@
   "signInPhoneChangeNumber": "Changer de numéro",
   "signInPhoneResendCode": "Renvoyer le code",
   "signInAuthBetaPill": "BETA",
+  "signInAndroidPwaInstallOverlayMessage": "Pour une meilleure expérience sur Android, installe l'application depuis GitHub.",
   "accountTitle": "Mon compte",
   "accountCropProfilePhotoTitle": "Recadrer la photo de profil",
   "accountPhotoUpdated": "Photo de profil mise à jour",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -502,6 +502,12 @@ abstract class AppLocalizations {
   /// **'BETA'**
   String get signInAuthBetaPill;
 
+  /// No description provided for @signInAndroidPwaInstallOverlayMessage.
+  ///
+  /// In fr, this message translates to:
+  /// **'Pour une meilleure expérience sur Android, installe l\'application depuis GitHub.'**
+  String get signInAndroidPwaInstallOverlayMessage;
+
   /// No description provided for @accountTitle.
   ///
   /// In fr, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -223,6 +223,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get signInAuthBetaPill => 'BETA';
 
   @override
+  String get signInAndroidPwaInstallOverlayMessage =>
+      'For a better Android experience, install the app from GitHub.';
+
+  @override
   String get accountTitle => 'My account';
 
   @override
@@ -2275,6 +2279,10 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
 
   @override
   String get signInAuthBetaPill => 'BETA';
+
+  @override
+  String get signInAndroidPwaInstallOverlayMessage =>
+      'For a better Android experience, install the app from GitHub.';
 
   @override
   String get accountTitle => 'My account';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -224,6 +224,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get signInAuthBetaPill => 'BETA';
 
   @override
+  String get signInAndroidPwaInstallOverlayMessage =>
+      'Pour une meilleure expérience sur Android, installe l\'application depuis GitHub.';
+
+  @override
   String get accountTitle => 'Mon compte';
 
   @override
@@ -2291,6 +2295,10 @@ class AppLocalizationsFrFr extends AppLocalizationsFr {
 
   @override
   String get signInAuthBetaPill => 'BETA';
+
+  @override
+  String get signInAndroidPwaInstallOverlayMessage =>
+      'Pour une meilleure expérience sur Android, installe l\'application depuis GitHub.';
 
   @override
   String get accountTitle => 'Mon compte';


### PR DESCRIPTION
## Summary
- Add Android PWA-mode detection and use it to gate sign-in options behind an APK install card until dismissed.
- Reuse a single shared GitHub APK download URL across sign-in and account menu actions.
- Align account badge download visibility with the exact same Android PWA condition as the sign-in install gate.

## Test plan
- [x] Run `flutter analyze` (only pre-existing infos remain outside touched files).
- [x] Verify sign-in gate appears only in Android PWA mode.
- [x] Verify dismissing the gate reveals the existing login methods.
- [x] Verify download action in account badge appears under the same Android PWA condition and opens the shared URL.