### PR TITLE
Fix production Firebase app options

### DIFF
--- a/lib/firebase_options_prod.dart
+++ b/lib/firebase_options_prod.dart
@@ -31,53 +31,51 @@ class DefaultFirebaseOptionsProd {
   }
 
   static const FirebaseOptions web = FirebaseOptions(
-    apiKey: 'AIzaSyC6N9_UQcpIiXNAh9VxlwYmYoYgw5L_WqM',
-    appId: '1:968267093466:web:c8bb48142b46a05cd29ce3',
-    messagingSenderId: '968267093466',
+    apiKey: 'AIzaSyDXFZrpXlQa1_FqNmbTVUsOlTcHDcs3pPU',
+    appId: '1:936277491452:web:1794a04a8c81d6f8f1e179',
+    messagingSenderId: '936277491452',
     projectId: 'planerz',
     authDomain: 'planerz.firebaseapp.com',
     storageBucket: 'planerz.firebasestorage.app',
-    measurementId: 'G-NGGPNLLR0J',
+    measurementId: 'G-Z68T9LKMH7',
   );
 
   static const FirebaseOptions android = FirebaseOptions(
-    apiKey: 'AIzaSyDAbqV4V0XhqdKQI-MShFzbl3JWuBGrNwo',
-    appId: '1:968267093466:android:dedcff179c3fc51fd29ce3',
-    messagingSenderId: '968267093466',
+    apiKey: 'AIzaSyBoTSZLo8BZqy21Aym5nwGMucnylehWnj0',
+    appId: '1:936277491452:android:43d7c2d65282a6ebf1e179',
+    messagingSenderId: '936277491452',
     projectId: 'planerz',
     storageBucket: 'planerz.firebasestorage.app',
   );
 
   static const FirebaseOptions ios = FirebaseOptions(
-    apiKey: 'AIzaSyA8hf0qUyo_3eWHBbuPN0B8WL8gWYEaEI0',
-    appId: '1:968267093466:ios:b4cefce64376cd54d29ce3',
-    messagingSenderId: '968267093466',
+    apiKey: 'AIzaSyC6e1d6ejoOofBGHmrk2Ts8Gkurfwj65Yg',
+    appId: '1:936277491452:ios:256ff6995b4d0ceef1e179',
+    messagingSenderId: '936277491452',
     projectId: 'planerz',
     storageBucket: 'planerz.firebasestorage.app',
-    androidClientId: '968267093466-flhm7osctcqf5g9npfqo0crtnor3s8om.apps.googleusercontent.com',
-    iosClientId: '968267093466-db1re1pv2r6ddpskp3khq15sf7o6sg8f.apps.googleusercontent.com',
+    iosClientId: '936277491452-34g7ggce0othki802d4sn4v5vkgmnn54.apps.googleusercontent.com',
     iosBundleId: 'fr.centuryspine.planerz',
   );
 
   static const FirebaseOptions macos = FirebaseOptions(
-    apiKey: 'AIzaSyA8hf0qUyo_3eWHBbuPN0B8WL8gWYEaEI0',
-    appId: '1:968267093466:ios:b4cefce64376cd54d29ce3',
-    messagingSenderId: '968267093466',
+    apiKey: 'AIzaSyC6e1d6ejoOofBGHmrk2Ts8Gkurfwj65Yg',
+    appId: '1:936277491452:ios:256ff6995b4d0ceef1e179',
+    messagingSenderId: '936277491452',
     projectId: 'planerz',
     storageBucket: 'planerz.firebasestorage.app',
-    androidClientId: '968267093466-flhm7osctcqf5g9npfqo0crtnor3s8om.apps.googleusercontent.com',
-    iosClientId: '968267093466-db1re1pv2r6ddpskp3khq15sf7o6sg8f.apps.googleusercontent.com',
+    iosClientId: '936277491452-34g7ggce0othki802d4sn4v5vkgmnn54.apps.googleusercontent.com',
     iosBundleId: 'fr.centuryspine.planerz',
   );
 
   static const FirebaseOptions windows = FirebaseOptions(
-    apiKey: 'AIzaSyC6N9_UQcpIiXNAh9VxlwYmYoYgw5L_WqM',
-    appId: '1:968267093466:web:f04bee3c5e841154d29ce3',
-    messagingSenderId: '968267093466',
+    apiKey: 'AIzaSyDXFZrpXlQa1_FqNmbTVUsOlTcHDcs3pPU',
+    appId: '1:936277491452:web:7682cb5708ece121f1e179',
+    messagingSenderId: '936277491452',
     projectId: 'planerz',
     authDomain: 'planerz.firebaseapp.com',
     storageBucket: 'planerz.firebasestorage.app',
-    measurementId: 'G-32WK1Q6N89',
+    measurementId: 'G-PR5BTR8MWV',
   );
 
 }

--- a/test/firebase_options_prod_test.dart
+++ b/test/firebase_options_prod_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:planerz/firebase_options_prod.dart';
+
+void main() {
+  test('production web Firebase options use the registered prod app', () {
+    final options = DefaultFirebaseOptionsProd.web;
+
+    expect(options.projectId, 'planerz');
+    expect(options.appId, '1:936277491452:web:1794a04a8c81d6f8f1e179');
+    expect(options.messagingSenderId, '936277491452');
+  });
+}

--- a/web/firebase-messaging-sw.js
+++ b/web/firebase-messaging-sw.js
@@ -3,13 +3,13 @@ importScripts('https://www.gstatic.com/firebasejs/10.13.2/firebase-app-compat.js
 importScripts('https://www.gstatic.com/firebasejs/10.13.2/firebase-messaging-compat.js');
 
 const prodConfig = {
-  apiKey: 'AIzaSyC6N9_UQcpIiXNAh9VxlwYmYoYgw5L_WqM',
-  appId: '1:968267093466:web:fe185a5604145fe3d29ce3',
-  messagingSenderId: '968267093466',
+  apiKey: 'AIzaSyDXFZrpXlQa1_FqNmbTVUsOlTcHDcs3pPU',
+  appId: '1:936277491452:web:1794a04a8c81d6f8f1e179',
+  messagingSenderId: '936277491452',
   projectId: 'planerz',
   authDomain: 'planerz.firebaseapp.com',
   storageBucket: 'planerz.firebasestorage.app',
-  measurementId: 'G-MDP337D1C0',
+  measurementId: 'G-Z68T9LKMH7',
 };
 
 const previewConfig = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Production now uses the same registered Firebase app options as the rest of the repository, so authenticated users on the production host should call the production backend with the expected Firebase project identity.

The web messaging service worker was aligned with the same production app options, and a regression test now guards the production web Firebase identifiers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aec233f9-900c-4968-9189-cc3600cb2874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aec233f9-900c-4968-9189-cc3600cb2874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

