### PR TITLE
feat: carpool, games & trips UX improvements

### DIFF
--- a/docs/plans/ajout_page_jeux.md
+++ b/docs/plans/ajout_page_jeux.md
@@ -12,7 +12,7 @@
 - La tuile existe déjà dans l’aperçu, mais son `onTap` est vide dans [`lib/features/trips/presentation/trip_overview_page.dart`](lib/features/trips/presentation/trip_overview_page.dart).
 - Pattern TabBar déjà utilisé sur les dépenses dans [`lib/features/expenses/presentation/trip_expenses_page.dart`](lib/features/expenses/presentation/trip_expenses_page.dart).
 - Pattern d’affichage des previews déjà prêt via:
-  - `LinkPreviewCardFromFirestore` et `LinkPreviewThumbnail` dans [`lib/features/trips/presentation/link_preview_from_firestore.dart`](lib/features/trips/presentation/link_preview_from_firestore.dart).
+  - `LinkPreviewCompact` et `LinkPreviewThumbnail` dans [`lib/features/trips/presentation/link_preview_from_firestore.dart`](lib/features/trips/presentation/link_preview_from_firestore.dart).
 - Pattern Cloud Functions Gen2 + region déjà en place dans [`functions/index.js`](functions/index.js) avec `setGlobalOptions({ region: 'europe-west9' })` et des triggers Firestore `onDocumentCreated/onDocumentUpdated`.
 - Firestore rules: les sous-collections de voyage sont protégées par `isTripMember(tripId)` et des conditions spécifiques dans [`firestore.rules`](firestore.rules).
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -75,9 +75,12 @@ async function fetchHtml(url) {
 
 function isGoogleMapsUrl(url) {
   const h = url.hostname;
+  const p = url.pathname || '';
   return (
     h === 'maps.google.com' ||
-    (h === 'www.google.com' && url.pathname.startsWith('/maps'))
+    (h === 'www.google.com' && p.startsWith('/maps')) ||
+    h === 'maps.app.goo.gl' ||
+    (h === 'goo.gl' && p.startsWith('/maps'))
   );
 }
 
@@ -2242,6 +2245,7 @@ async function generateLinkPreview(docRef, beforeUrlRaw, afterUrlRaw, previewFie
           status: 'error',
           url: afterUrl,
           error: 'invalid_url',
+          isGoogleMaps: false,
           fetchedAt: FieldValue.serverTimestamp(),
         },
       },
@@ -2255,6 +2259,7 @@ async function generateLinkPreview(docRef, beforeUrlRaw, afterUrlRaw, previewFie
       [previewField]: {
         status: 'loading',
         url: parsed.toString(),
+        isGoogleMaps: isGoogleMapsUrl(parsed),
         fetchedAt: FieldValue.serverTimestamp(),
       },
     },
@@ -2295,6 +2300,7 @@ async function generateLinkPreview(docRef, beforeUrlRaw, afterUrlRaw, previewFie
           description: preview.description,
           siteName: preview.siteName,
           imageUrl: preview.imageUrl,
+          isGoogleMaps: isGoogleMapsUrl(finalUrl),
           fetchedAt: FieldValue.serverTimestamp(),
         },
       },
@@ -2307,6 +2313,7 @@ async function generateLinkPreview(docRef, beforeUrlRaw, afterUrlRaw, previewFie
           status: 'error',
           url: parsed.toString(),
           error: String(e),
+          isGoogleMaps: isGoogleMapsUrl(parsed),
           fetchedAt: FieldValue.serverTimestamp(),
         },
       },

--- a/lib/features/activities/presentation/trip_activity_detail_page.dart
+++ b/lib/features/activities/presentation/trip_activity_detail_page.dart
@@ -472,7 +472,7 @@ class _ReadBody extends ConsumerWidget {
       padding: const EdgeInsets.all(16),
       children: [
         if (activity.linkUrl.trim().isNotEmpty) ...[
-          LinkPreviewCardFromFirestore(
+          LinkPreviewCompact(
             url: activity.linkUrl.trim(),
             preview: activity.linkPreview,
           ),
@@ -761,7 +761,7 @@ class _EditBodyState extends State<_EditBody> {
           ],
           if (showLivePreview) ...[
             const SizedBox(height: 12),
-            LinkPreviewCardFromFirestore(
+            LinkPreviewCompact(
               url: linkTrimmed,
               preview: widget.activity.linkPreview,
             ),

--- a/lib/features/carpool/presentation/trip_carpool_form_page.dart
+++ b/lib/features/carpool/presentation/trip_carpool_form_page.dart
@@ -336,6 +336,107 @@ class _TripCarpoolFormPageState extends ConsumerState<TripCarpoolFormPage> {
                   return leftLabel.toLowerCase().compareTo(rightLabel.toLowerCase());
                 });
 
+              if (_isReadOnly) {
+                final colorScheme = Theme.of(context).colorScheme;
+                final textTheme = Theme.of(context).textTheme;
+                final labelStyle = textTheme.labelSmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                );
+                final valueStyle = textTheme.bodyLarge;
+
+                Widget readOnlyField(String label, String value) => Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(label, style: labelStyle),
+                        const SizedBox(height: 2),
+                        Text(
+                          value.trim().isEmpty ? l10n.commonNotProvided : value.trim(),
+                          style: valueStyle,
+                        ),
+                      ],
+                    );
+
+                return ListView(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+                  children: [
+                    readOnlyField(
+                      l10n.tripCarpoolMeetingPointLabel,
+                      _meetingController.text,
+                    ),
+                    const Divider(height: 32),
+                    readOnlyField(
+                      l10n.tripCarpoolNearestTransitStopLabel,
+                      _transitController.text,
+                    ),
+                    const Divider(height: 32),
+                    readOnlyField(
+                      l10n.tripCarpoolDepartureAtLabel,
+                      _departureAt == null
+                          ? ''
+                          : '${MaterialLocalizations.of(context).formatMediumDate(_departureAt!)} ${MaterialLocalizations.of(context).formatTimeOfDay(TimeOfDay.fromDateTime(_departureAt!), alwaysUse24HourFormat: true)}',
+                    ),
+                    const Divider(height: 32),
+                    readOnlyField(
+                      l10n.tripCarpoolDriverLabel,
+                      _driverUserId?.trim().isNotEmpty == true
+                          ? (memberLabels[_driverUserId!.trim()] ?? l10n.tripParticipantsTraveler)
+                          : '',
+                    ),
+                    const Divider(height: 32),
+                    readOnlyField(
+                      l10n.tripCarpoolAvailableSeatsLabel,
+                      _seatsController.text.trim(),
+                    ),
+                    const Divider(height: 32),
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(l10n.tripCarpoolGoesShoppingLabel, style: labelStyle),
+                        const SizedBox(height: 4),
+                        Icon(
+                          _goesShopping
+                              ? Icons.shopping_cart_outlined
+                              : Icons.remove,
+                          size: 20,
+                          color: _goesShopping
+                              ? colorScheme.primary
+                              : colorScheme.onSurfaceVariant,
+                        ),
+                      ],
+                    ),
+                    const Divider(height: 32),
+                    Text(
+                      l10n.tripCarpoolPassengersTitle,
+                      style: textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    Card(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          for (final memberId in sortedParticipantIds)
+                            if (_selectedParticipantIds.contains(memberId))
+                              ListTile(
+                                dense: true,
+                                leading: Icon(
+                                  memberId == _driverUserId?.trim()
+                                      ? Icons.drive_eta_outlined
+                                      : Icons.person_outline,
+                                  size: 20,
+                                ),
+                                title: Text(
+                                  memberLabels[memberId] ?? l10n.tripParticipantsTraveler,
+                                ),
+                              ),
+                        ],
+                      ),
+                    ),
+                  ],
+                );
+              }
+
               return Form(
                 key: _formKey,
                 child: ListView(

--- a/lib/features/carpool/presentation/trip_carpool_page.dart
+++ b/lib/features/carpool/presentation/trip_carpool_page.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:intl/intl.dart';
 import 'package:planerz/features/auth/data/user_display_label.dart';
 import 'package:planerz/features/auth/presentation/profile_badge.dart';
 import 'package:planerz/features/auth/data/users_repository.dart';
@@ -606,6 +607,10 @@ class _TripCarpoolCard extends StatelessWidget {
       TimeOfDay.fromDateTime(carpool.departureAt),
       alwaysUse24HourFormat: true,
     );
+    final departureDateLabel = DateFormat(
+      'd MMM',
+      Localizations.localeOf(context).toString(),
+    ).format(carpool.departureAt);
     final remainingSeats =
         carpool.availableSeats - carpool.assignedParticipantIds.length;
     final meetingPointLabel = carpool.meetingPointAddress.trim().isEmpty
@@ -719,6 +724,7 @@ class _TripCarpoolCard extends StatelessWidget {
                 TextSpan(
                   style: meetingLineStyle,
                   children: [
+                    TextSpan(text: '$departureDateLabel, '),
                     TextSpan(text: '$departureTime - '),
                     TextSpan(text: meetingPointLabel),
                     WidgetSpan(

--- a/lib/features/carpool/presentation/trip_carpool_page.dart
+++ b/lib/features/carpool/presentation/trip_carpool_page.dart
@@ -416,12 +416,10 @@ class _TripCarpoolPageState extends ConsumerState<TripCarpoolPage> {
                                 if (carpoolSection.shoppingMeetupLinkUrl
                                     .trim()
                                     .isNotEmpty) ...[
-                                  LinkPreviewCardFromFirestore(
+                                  LinkPreviewCompact(
                                     url: carpoolSection.shoppingMeetupLinkUrl,
                                     preview: carpoolSection
                                         .shoppingMeetupLinkPreview,
-                                    showCard: true,
-                                    showTitleLabel: false,
                                   ),
                                 ],
                               ],

--- a/lib/features/carpool/presentation/trip_carpool_page.dart
+++ b/lib/features/carpool/presentation/trip_carpool_page.dart
@@ -329,106 +329,105 @@ class _TripCarpoolPageState extends ConsumerState<TripCarpoolPage> {
                         const SizedBox(height: 12),
                       ],
                       if (showGlobalShoppingMeetupSection) ...[
-                        Card(
-                          child: Padding(
-                            padding: const EdgeInsets.all(16),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
                               children: [
-                                Row(
-                                  children: [
-                                    Expanded(
-                                      child: Text(
-                                        l10n.tripCarpoolGlobalMeetupTitle,
-                                        style: Theme.of(context)
-                                            .textTheme
-                                            .titleMedium,
-                                      ),
-                                    ),
-                                    if (canEditGlobalMeetup &&
-                                        !_isEditingGlobalMeetup)
-                                      IconButton(
-                                        tooltip: l10n.commonEdit,
-                                        visualDensity: VisualDensity.compact,
-                                        padding: EdgeInsets.zero,
-                                        constraints: const BoxConstraints(
-                                          minWidth: 28,
-                                          minHeight: 28,
-                                        ),
-                                        onPressed: () {
-                                          setState(() {
-                                            _isEditingGlobalMeetup = true;
-                                            _globalMeetupController.text =
-                                                carpoolSection
-                                                    .shoppingMeetupLinkUrl;
-                                          });
-                                        },
-                                        icon: const Icon(Icons.edit_outlined),
-                                      ),
-                                  ],
+                                Expanded(
+                                  child: Text(
+                                    l10n.tripCarpoolGlobalMeetupTitle,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .titleMedium,
+                                  ),
                                 ),
-                                const SizedBox(height: 4),
                                 if (canEditGlobalMeetup &&
-                                    (_isEditingGlobalMeetup ||
-                                        carpoolSection.shoppingMeetupLinkUrl
-                                            .trim()
-                                            .isEmpty))
-                                  TextFormField(
-                                    controller: _globalMeetupController,
-                                    focusNode: _globalMeetupFocusNode,
-                                    decoration: InputDecoration(
-                                      labelText:
-                                          l10n.tripCarpoolGlobalMeetupLabel,
-                                      border: const OutlineInputBorder(),
-                                      suffixIcon: canEditGlobalMeetup
-                                          ? IconButton(
-                                              tooltip: l10n.commonSave,
-                                              onPressed: _isSavingGlobalMeetup
-                                                  ? null
-                                                  : () => _saveGlobalMeetupLink(
-                                                        tripId: trip.id,
-                                                        canEditGlobalMeetup:
-                                                            canEditGlobalMeetup,
-                                                      ),
-                                              icon: _isSavingGlobalMeetup
-                                                  ? const SizedBox(
-                                                      width: 18,
-                                                      height: 18,
-                                                      child:
-                                                          CircularProgressIndicator(
-                                                        strokeWidth: 2,
-                                                      ),
-                                                    )
-                                                  : const Icon(Icons.check),
-                                            )
-                                          : null,
+                                    !_isEditingGlobalMeetup)
+                                  IconButton(
+                                    tooltip: l10n.commonEdit,
+                                    style: IconButton.styleFrom(
+                                      tapTargetSize:
+                                          MaterialTapTargetSize.shrinkWrap,
+                                      padding: EdgeInsets.zero,
                                     ),
+                                    onPressed: () {
+                                      setState(() {
+                                        _isEditingGlobalMeetup = true;
+                                        _globalMeetupController.text =
+                                            carpoolSection
+                                                .shoppingMeetupLinkUrl;
+                                      });
+                                    },
+                                    icon: const Icon(Icons.edit_outlined),
                                   ),
-                                if (!canEditGlobalMeetup &&
-                                    carpoolSection.shoppingMeetupLinkUrl
-                                        .trim()
-                                        .isEmpty)
-                                  Text(
-                                    l10n.commonNotProvided,
-                                    style:
-                                        Theme.of(context).textTheme.bodyMedium,
-                                  ),
-                                const SizedBox(height: 10),
-                                if (carpoolSection.shoppingMeetupLinkUrl
-                                    .trim()
-                                    .isNotEmpty) ...[
-                                  LinkPreviewCompact(
-                                    url: carpoolSection.shoppingMeetupLinkUrl,
-                                    preview: carpoolSection
-                                        .shoppingMeetupLinkPreview,
-                                  ),
-                                ],
                               ],
                             ),
-                          ),
+                            const SizedBox(height: 4),
+                            if (canEditGlobalMeetup &&
+                                (_isEditingGlobalMeetup ||
+                                    carpoolSection.shoppingMeetupLinkUrl
+                                        .trim()
+                                        .isEmpty))
+                              TextFormField(
+                                controller: _globalMeetupController,
+                                focusNode: _globalMeetupFocusNode,
+                                decoration: InputDecoration(
+                                  labelText:
+                                      l10n.tripCarpoolGlobalMeetupLabel,
+                                  border: const OutlineInputBorder(),
+                                  suffixIcon: canEditGlobalMeetup
+                                      ? IconButton(
+                                          tooltip: l10n.commonSave,
+                                          onPressed: _isSavingGlobalMeetup
+                                              ? null
+                                              : () => _saveGlobalMeetupLink(
+                                                    tripId: trip.id,
+                                                    canEditGlobalMeetup:
+                                                        canEditGlobalMeetup,
+                                                  ),
+                                          icon: _isSavingGlobalMeetup
+                                              ? const SizedBox(
+                                                  width: 18,
+                                                  height: 18,
+                                                  child:
+                                                      CircularProgressIndicator(
+                                                    strokeWidth: 2,
+                                                  ),
+                                                )
+                                              : const Icon(Icons.check),
+                                        )
+                                      : null,
+                                ),
+                              ),
+                            if (!canEditGlobalMeetup &&
+                                carpoolSection.shoppingMeetupLinkUrl
+                                    .trim()
+                                    .isEmpty)
+                              Text(
+                                l10n.commonNotProvided,
+                                style:
+                                    Theme.of(context).textTheme.bodyMedium,
+                              ),
+                            const SizedBox(height: 10),
+                            if (carpoolSection.shoppingMeetupLinkUrl
+                                .trim()
+                                .isNotEmpty) ...[
+                              LinkPreviewCompact(
+                                url: carpoolSection.shoppingMeetupLinkUrl,
+                                preview: carpoolSection
+                                    .shoppingMeetupLinkPreview,
+                              ),
+                            ],
+                          ],
                         ),
                         const SizedBox(height: 12),
                       ],
+                      Text(
+                        l10n.tripCarpoolCarsTitle,
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
                       if (carpools.isEmpty)
                         Card(
                           child: Padding(

--- a/lib/features/games/presentation/trip_games_page.dart
+++ b/lib/features/games/presentation/trip_games_page.dart
@@ -223,8 +223,8 @@ class _TripGamesPageState extends ConsumerState<TripGamesPage>
 
                       return Card(
                         child: ListTile(
-                          minVerticalPadding: 8,
-                          minTileHeight: 72,
+                          minVerticalPadding: 4,
+                          minTileHeight: 60,
                           leading: buildProfileBadge(
                             context: context,
                             displayLabel: creatorLabel,
@@ -232,16 +232,12 @@ class _TripGamesPageState extends ConsumerState<TripGamesPage>
                             size: 30,
                           ),
                           title: Text(
-                            game.name.isEmpty ? l10n.activitiesUntitled : game.name,
+                            game.name.isEmpty
+                                ? l10n.activitiesUntitled
+                                : game.name,
                           ),
-                          subtitle: game.linkUrl.trim().isEmpty
-                              ? null
-                              : Text(
-                                  game.linkUrl,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                          trailing: LinkPreviewThumbnail(preview: game.linkPreview),
+                          trailing:
+                              LinkPreviewThumbnail(preview: game.linkPreview),
                           onTap: () => _openBoardGameDialog(
                             tripId: trip.id,
                             game: game,
@@ -255,12 +251,11 @@ class _TripGamesPageState extends ConsumerState<TripGamesPage>
                 ],
               ),
               floatingActionButton: FloatingActionButton(
-                onPressed: () =>
-                    _openBoardGameDialog(
-                      tripId: trip.id,
-                      canEdit: true,
-                      canDelete: false,
-                    ),
+                onPressed: () => _openBoardGameDialog(
+                  tripId: trip.id,
+                  canEdit: true,
+                  canDelete: false,
+                ),
                 tooltip: l10n.tripGamesAdd,
                 child: const Icon(Icons.add),
               ),
@@ -554,8 +549,9 @@ class _BoardGameDialogState extends State<_BoardGameDialog> {
                   }
                   _cancelExistingEdit();
                 },
-                child: Text(
-                    (isEdit && !isReadOnly) ? l10n.commonCancel : l10n.commonClose),
+                child: Text((isEdit && !isReadOnly)
+                    ? l10n.commonCancel
+                    : l10n.commonClose),
               ),
               if (!isReadOnly)
                 FilledButton.icon(

--- a/lib/features/games/presentation/trip_games_page.dart
+++ b/lib/features/games/presentation/trip_games_page.dart
@@ -176,7 +176,7 @@ class _TripGamesPageState extends ConsumerState<TripGamesPage>
                   ListView.separated(
                     padding: const EdgeInsets.fromLTRB(16, 12, 16, 90),
                     itemCount: listItemCount,
-                    separatorBuilder: (_, __) => const SizedBox(height: 8),
+                    separatorBuilder: (_, __) => const SizedBox(height: 4),
                     itemBuilder: (context, index) {
                       if (index == 0) {
                         return Text(

--- a/lib/features/trips/presentation/link_preview_from_firestore.dart
+++ b/lib/features/trips/presentation/link_preview_from_firestore.dart
@@ -3,23 +3,27 @@ import 'package:flutter/material.dart';
 import 'package:planerz/l10n/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-/// Renders Open Graph / meta preview data stored on a Firestore document
-/// (`linkPreview` map), same shape as trip overview and trip activities.
-class LinkPreviewCardFromFirestore extends StatelessWidget {
-  const LinkPreviewCardFromFirestore({
+/// Compact visual representation of a `linkPreview` map stored on a Firestore
+/// document. Used everywhere a saved link is shown to the user.
+///
+/// Layout: thumbnail + clickable title (or URL) with the URL as subtext.
+/// The whole row is tappable and opens the link via [launchUrl]. Callers can
+/// supply an optional [trailing] widget (e.g. a "directions" icon button) for
+/// contextual side-actions; that widget receives its own taps independently
+/// from the main link area.
+class LinkPreviewCompact extends StatelessWidget {
+  const LinkPreviewCompact({
     super.key,
     required this.url,
     required this.preview,
-    this.titleLabel,
+    this.trailing,
     this.showCard = true,
-    this.showTitleLabel = true,
   });
 
   final String url;
   final Map<String, dynamic> preview;
-  final String? titleLabel;
+  final Widget? trailing;
   final bool showCard;
-  final bool showTitleLabel;
 
   Future<void> _openLink(BuildContext context) async {
     final l10n = AppLocalizations.of(context)!;
@@ -46,132 +50,75 @@ class LinkPreviewCardFromFirestore extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    final status = (preview['status'] as String?) ?? '';
-    final title = (preview['title'] as String?) ?? '';
-    final description = (preview['description'] as String?) ?? '';
-    final siteName = (preview['siteName'] as String?) ?? '';
-    final imageUrl = (preview['imageUrl'] as String?) ?? '';
+    final cs = Theme.of(context).colorScheme;
+    final previewTitle = ((preview['title'] as String?) ?? '').trim();
+    final primaryText = previewTitle.isNotEmpty ? previewTitle : url;
 
-    final hasPreview = title.trim().isNotEmpty ||
-        description.trim().isNotEmpty ||
-        imageUrl.trim().isNotEmpty ||
-        siteName.trim().isNotEmpty;
-
-    final content = Padding(
-      padding: const EdgeInsets.all(12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (showTitleLabel) ...[
-            Text(
-              titleLabel ?? l10n.linkLabel,
-              style: Theme.of(context).textTheme.titleMedium,
-            ),
-            const SizedBox(height: 8),
-          ],
-          InkWell(
+    final row = Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Expanded(
+          child: InkWell(
             onTap: () => _openLink(context),
-            borderRadius: BorderRadius.circular(6),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    url,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Theme.of(context).colorScheme.tertiary,
-                          decoration: TextDecoration.underline,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 6),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  LinkPreviewThumbnail(preview: preview, size: 48),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          primaryText,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodyMedium
+                              ?.copyWith(
+                                color: cs.tertiary,
+                                decoration: TextDecoration.underline,
+                                fontWeight: FontWeight.w600,
+                              ),
                         ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Icon(
-                  Icons.open_in_new,
-                  size: 18,
-                  color: Theme.of(context).colorScheme.tertiary,
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 12),
-          if (status == 'loading') ...[
-            const SizedBox(
-              height: 120,
-              child: Center(child: CircularProgressIndicator()),
-            ),
-          ] else if (!hasPreview) ...[
-            Text(
-              l10n.linkPreviewUnavailable,
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-          ] else ...[
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (imageUrl.trim().isNotEmpty) ...[
-                  ClipRRect(
-                    borderRadius: BorderRadius.circular(8),
-                    child: Image.network(
-                      imageUrl,
-                      width: 96,
-                      height: 96,
-                      fit: BoxFit.cover,
-                      webHtmlElementStrategy: kIsWeb
-                          ? WebHtmlElementStrategy.prefer
-                          : WebHtmlElementStrategy.never,
-                      errorBuilder: (_, __, ___) => Container(
-                        width: 96,
-                        height: 96,
-                        color: Theme.of(context)
-                            .colorScheme
-                            .surfaceContainerHighest,
-                        alignment: Alignment.center,
-                        child: const Icon(Icons.broken_image_outlined),
-                      ),
+                        if (previewTitle.isNotEmpty) ...[
+                          const SizedBox(height: 2),
+                          Text(
+                            url,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodySmall
+                                ?.copyWith(color: cs.onSurfaceVariant),
+                          ),
+                        ],
+                      ],
                     ),
                   ),
-                  const SizedBox(width: 12),
                 ],
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (siteName.trim().isNotEmpty) ...[
-                        Text(
-                          siteName,
-                          style: Theme.of(context).textTheme.labelLarge,
-                        ),
-                        const SizedBox(height: 4),
-                      ],
-                      if (title.trim().isNotEmpty) ...[
-                        Text(
-                          title,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.titleSmall,
-                        ),
-                      ],
-                      if (description.trim().isNotEmpty) ...[
-                        const SizedBox(height: 4),
-                        Text(
-                          description,
-                          maxLines: 3,
-                          overflow: TextOverflow.ellipsis,
-                          style: Theme.of(context).textTheme.bodySmall,
-                        ),
-                      ],
-                    ],
-                  ),
-                ),
-              ],
+              ),
             ),
-          ],
+          ),
+        ),
+        if (trailing != null) ...[
+          const SizedBox(width: 8),
+          trailing!,
         ],
-      ),
+      ],
     );
 
-    if (!showCard) return content;
-    return Card(child: content);
+    if (!showCard) return row;
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: row,
+      ),
+    );
   }
 }
 

--- a/lib/features/trips/presentation/trip_overview_page.dart
+++ b/lib/features/trips/presentation/trip_overview_page.dart
@@ -1231,37 +1231,37 @@ class _TripOverviewPageState extends ConsumerState<TripOverviewPage> {
                             ],
                           ),
                         ),
-                      Card(
-                        child: Padding(
-                          padding: const EdgeInsets.all(16),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              if (linkUrlForUi.isNotEmpty) ...[
-                                LinkPreviewCardFromFirestore(
-                                  url: linkUrlForUi,
-                                  preview: livePreview,
-                                  showCard: false,
-                                  showTitleLabel: false,
-                                ),
-                                const SizedBox(height: 12),
-                              ],
-                              _InfoRow(
-                                label: l10n.tripOverviewAddressLabel,
-                                value: _trip.address,
-                                actionIcon: Icons.location_on_outlined,
-                                onActionPressed: _trip.address.trim().isEmpty
-                                    ? null
-                                    : () => openAddressInGoogleMaps(
+                      if (linkUrlForUi.isNotEmpty)
+                        Builder(builder: (context) {
+                          final cs = Theme.of(context).colorScheme;
+                          final isMapsLink =
+                              livePreview['isGoogleMaps'] == true;
+                          final hasAddress = _trip.address.trim().isNotEmpty;
+                          final showDirections = isMapsLink || hasAddress;
+                          return LinkPreviewCompact(
+                            url: linkUrlForUi,
+                            preview: livePreview,
+                            trailing: showDirections
+                                ? IconButton(
+                                    tooltip: l10n.tripOverviewOpenLocation,
+                                    icon: const Icon(
+                                      Icons.directions_outlined,
+                                    ),
+                                    color: cs.tertiary,
+                                    onPressed: () {
+                                      if (isMapsLink) {
+                                        _openLinkUrl(linkUrlForUi);
+                                      } else {
+                                        openAddressInGoogleMaps(
                                           context,
                                           _trip.address,
-                                        ),
-                                actionTooltip: l10n.tripOverviewOpenLocation,
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
+                                        );
+                                      }
+                                    },
+                                  )
+                                : null,
+                          );
+                        }),
                       if (!_isEditing) ...[
                         const SizedBox(height: 12),
                         Builder(builder: (context) {
@@ -1455,57 +1455,6 @@ class _TripBanner extends StatelessWidget {
                       ),
               ),
       ),
-    );
-  }
-}
-
-class _InfoRow extends StatelessWidget {
-  const _InfoRow({
-    required this.label,
-    required this.value,
-    this.actionIcon,
-    this.onActionPressed,
-    this.actionTooltip,
-  });
-
-  final String label;
-  final String value;
-  final IconData? actionIcon;
-  final VoidCallback? onActionPressed;
-  final String? actionTooltip;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        SizedBox(
-          width: 110,
-          child: Text(
-            label,
-            style: Theme.of(context).textTheme.labelLarge,
-          ),
-        ),
-        Expanded(
-          child: Text(
-            value.isEmpty ? '-' : value,
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-        ),
-        if (actionIcon != null)
-          IconButton(
-            tooltip: actionTooltip,
-            onPressed: onActionPressed,
-            icon: Icon(actionIcon),
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(
-              minWidth: 32,
-              minHeight: 32,
-            ),
-            visualDensity: VisualDensity.compact,
-            splashRadius: 18,
-          ),
-      ],
     );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -924,6 +924,7 @@
       }
     }
   },
+  "tripCarpoolCarsTitle": "Cars",
   "tripCarpoolGlobalMeetupTitle": "Shopping meetup",
   "tripCarpoolGlobalMeetupLabel": "Google Maps link",
   "tripCarpoolOpenMapsLink": "Open Google Maps link",

--- a/lib/l10n/app_en_US.arb
+++ b/lib/l10n/app_en_US.arb
@@ -924,6 +924,7 @@
       }
     }
   },
+  "tripCarpoolCarsTitle": "Cars",
   "tripCarpoolGlobalMeetupTitle": "Shopping meetup",
   "tripCarpoolGlobalMeetupLabel": "Google Maps link",
   "tripCarpoolOpenMapsLink": "Open Google Maps link",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -924,6 +924,7 @@
       }
     }
   },
+  "tripCarpoolCarsTitle": "Voitures",
   "tripCarpoolGlobalMeetupTitle": "Rendez-vous courses",
   "tripCarpoolGlobalMeetupLabel": "Lien Google Maps",
   "tripCarpoolOpenMapsLink": "Ouvrir le lien Google Maps",

--- a/lib/l10n/app_fr_FR.arb
+++ b/lib/l10n/app_fr_FR.arb
@@ -924,6 +924,7 @@
       }
     }
   },
+  "tripCarpoolCarsTitle": "Voitures",
   "tripCarpoolGlobalMeetupTitle": "Rendez-vous courses",
   "tripCarpoolGlobalMeetupLabel": "Lien Google Maps",
   "tripCarpoolOpenMapsLink": "Ouvrir le lien Google Maps",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4268,6 +4268,12 @@ abstract class AppLocalizations {
   /// **'{count} participant(s) n\'est/ne sont assigné(s) à aucune voiture.'**
   String tripCarpoolUnassignedWarningBody(int count);
 
+  /// No description provided for @tripCarpoolCarsTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Voitures'**
+  String get tripCarpoolCarsTitle;
+
   /// No description provided for @tripCarpoolGlobalMeetupTitle.
   ///
   /// In fr, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2338,6 +2338,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get tripCarpoolCarsTitle => 'Cars';
+
+  @override
   String get tripCarpoolGlobalMeetupTitle => 'Shopping meetup';
 
   @override
@@ -4881,6 +4884,9 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
   String tripCarpoolUnassignedWarningBody(int count) {
     return '$count participant(s) are not assigned to any carpool.';
   }
+
+  @override
+  String get tripCarpoolCarsTitle => 'Cars';
 
   @override
   String get tripCarpoolGlobalMeetupTitle => 'Shopping meetup';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2356,6 +2356,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get tripCarpoolCarsTitle => 'Voitures';
+
+  @override
   String get tripCarpoolGlobalMeetupTitle => 'Rendez-vous courses';
 
   @override
@@ -4921,6 +4924,9 @@ class AppLocalizationsFrFr extends AppLocalizationsFr {
   String tripCarpoolUnassignedWarningBody(int count) {
     return '$count participant(s) n\'est/ne sont assigné(s) à aucune voiture.';
   }
+
+  @override
+  String get tripCarpoolCarsTitle => 'Voitures';
 
   @override
   String get tripCarpoolGlobalMeetupTitle => 'Rendez-vous courses';


### PR DESCRIPTION
﻿## Summary

- **Covoiturage :** nouvelle vue lecture seule avec date de depart visible sur la carte ; section Rendez-vous courses restructuree sans Card, ajout d'un titre Voitures avant la liste.
- **Jeux :** lignes de la liste condensees avec miniature portrait, espacement reduit entre les rangees.
- **Voyages :** apercu de lien compact (miniature + titre + URL) dans la vue d'ensemble, le detail d'activite, le formulaire d'edition et la section courses du covoiturage ; raccourci itineraire en un tap (icone directions) qui ouvre Maps directement depuis l'adresse ou le lien.

## Test plan

- [ ] Carpool : verifier l'affichage de la date/heure sur une carte de covoiturage dont la date differe du jour du voyage.
- [ ] Carpool : ouvrir un covoiturage existant, vue lecture seule, puis taper Modifier, formulaire.
- [ ] Carpool : verifier le titre Voitures et l'absence de Card sur la section Rendez-vous courses.
- [ ] Jeux : verifier la hauteur des lignes et la miniature portrait dans la liste de jeux.
- [ ] Voyages : verifier l'apercu de lien compact dans la vue d'ensemble et le detail d'activite.
- [ ] Voyages : taper l'icone directions depuis une adresse ou un lien Maps, ouverture correcte.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the shared link preview component and extends Cloud Functions link-preview writes with a new `isGoogleMaps` field, which can affect multiple screens’ rendering/behavior. Remaining changes are mostly UI/layout adjustments in carpool and games pages.
> 
> **Overview**
> Introduces a new compact link preview UI (`LinkPreviewCompact`) and replaces the previous card-based preview in trip overview, activity detail, and carpool meetup sections; trip overview now optionally shows a one-tap *directions* trailing action based on whether the link/address is Google Maps.
> 
> Updates the link-preview Cloud Function to better detect Google Maps URLs (including short/app links) and persist an `isGoogleMaps` flag for `loading`/`ok`/`error` preview states.
> 
> Improves carpool UX with a dedicated read-only display in the form, a restructured “shopping meetup” section plus a new **Cars** header, and shows a localized departure date label on carpool cards. Games list rows are condensed (spacing/height) while keeping thumbnail previews.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e2771dc37a268a6921938a5b31f555a01b26438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->