### PR TITLE
feat(meals): confirmation avant suppression d’un composant (mode cuisine)

### DIFF
--- a/lib/features/meals/presentation/trip_meal_details_page.dart
+++ b/lib/features/meals/presentation/trip_meal_details_page.dart
@@ -829,6 +829,33 @@ class _TripMealDetailsPageState extends ConsumerState<TripMealDetailsPage> {
     );
   }
 
+  Future<void> _confirmDeleteComponent(MealComponent component) async {
+    final l10n = AppLocalizations.of(context)!;
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(l10n.mealDeleteComponentConfirmTitle),
+        content: Text(
+          l10n.mealDeleteComponentConfirmBody(
+            _componentKindLabel(l10n, component.kind),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(l10n.commonCancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(l10n.commonDelete),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true || !mounted) return;
+    await _deleteComponent(component.id);
+  }
+
   Future<void> _reorderComponents(int oldIndex, int newIndex) async {
     final previousComponents = _components;
     final previousComponentsUserOrdered = _componentsUserOrdered;
@@ -1999,8 +2026,8 @@ class _TripMealDetailsPageState extends ConsumerState<TripMealDetailsPage> {
                                                       )
                                                         ? null
                                                         : () =>
-                                                            _deleteComponent(
-                                                              component.id,
+                                                            _confirmDeleteComponent(
+                                                              component,
                                                             ),
                                                 icon: Icon(Icons.delete_outline,
                                                     color: Theme.of(context)

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -754,6 +754,13 @@
   "@mealComponentLockedByUser": {"placeholders": {"user": {}}},
   "mealComponentChangedUnsaved": "Modified component not saved",
   "mealDeleteComponent": "Delete this component",
+  "mealDeleteComponentConfirmTitle": "Remove this component?",
+  "mealDeleteComponentConfirmBody": "The \"{componentKind}\" course will be removed from this meal.",
+  "@mealDeleteComponentConfirmBody": {
+    "placeholders": {
+      "componentKind": {}
+    }
+  },
   "mealModeCooked": "Home-cooked meal",
   "mealModeRestaurant": "Restaurant",
   "mealModePotluck": "Potluck",

--- a/lib/l10n/app_en_US.arb
+++ b/lib/l10n/app_en_US.arb
@@ -716,6 +716,13 @@
   "@mealComponentLockedByUser": {"placeholders": {"user": {}}},
   "mealComponentChangedUnsaved": "Modified component not saved",
   "mealDeleteComponent": "Delete this component",
+  "mealDeleteComponentConfirmTitle": "Remove this component?",
+  "mealDeleteComponentConfirmBody": "The \"{componentKind}\" course will be removed from this meal.",
+  "@mealDeleteComponentConfirmBody": {
+    "placeholders": {
+      "componentKind": {}
+    }
+  },
   "mealModeCooked": "Home-cooked meal",
   "mealModeRestaurant": "Restaurant",
   "mealModePotluck": "Potluck",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -754,6 +754,13 @@
   "@mealComponentLockedByUser": {"placeholders": {"user": {}}},
   "mealComponentChangedUnsaved": "Composant modifié non enregistré",
   "mealDeleteComponent": "Supprimer ce composant",
+  "mealDeleteComponentConfirmTitle": "Supprimer ce composant ?",
+  "mealDeleteComponentConfirmBody": "Le composant « {componentKind} » sera retiré de ce repas.",
+  "@mealDeleteComponentConfirmBody": {
+    "placeholders": {
+      "componentKind": {}
+    }
+  },
   "mealModeCooked": "Repas cuisiné",
   "mealModeRestaurant": "Restaurant",
   "mealModePotluck": "Auberge espagnole",

--- a/lib/l10n/app_fr_FR.arb
+++ b/lib/l10n/app_fr_FR.arb
@@ -716,6 +716,13 @@
   "@mealComponentLockedByUser": {"placeholders": {"user": {}}},
   "mealComponentChangedUnsaved": "Composant modifié non enregistré",
   "mealDeleteComponent": "Supprimer ce composant",
+  "mealDeleteComponentConfirmTitle": "Supprimer ce composant ?",
+  "mealDeleteComponentConfirmBody": "Le composant « {componentKind} » sera retiré de ce repas.",
+  "@mealDeleteComponentConfirmBody": {
+    "placeholders": {
+      "componentKind": {}
+    }
+  },
   "mealModeCooked": "Repas cuisiné",
   "mealModeRestaurant": "Restaurant",
   "mealModePotluck": "Auberge espagnole",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3474,6 +3474,18 @@ abstract class AppLocalizations {
   /// **'Supprimer ce composant'**
   String get mealDeleteComponent;
 
+  /// No description provided for @mealDeleteComponentConfirmTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Supprimer ce composant ?'**
+  String get mealDeleteComponentConfirmTitle;
+
+  /// No description provided for @mealDeleteComponentConfirmBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'Le composant « {componentKind} » sera retiré de ce repas.'**
+  String mealDeleteComponentConfirmBody(Object componentKind);
+
   /// No description provided for @mealModeCooked.
   ///
   /// In fr, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1896,6 +1896,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mealDeleteComponent => 'Delete this component';
 
   @override
+  String get mealDeleteComponentConfirmTitle => 'Remove this component?';
+
+  @override
+  String mealDeleteComponentConfirmBody(Object componentKind) {
+    return 'The \"$componentKind\" course will be removed from this meal.';
+  }
+
+  @override
   String get mealModeCooked => 'Home-cooked meal';
 
   @override
@@ -4512,6 +4520,14 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
 
   @override
   String get mealDeleteComponent => 'Delete this component';
+
+  @override
+  String get mealDeleteComponentConfirmTitle => 'Remove this component?';
+
+  @override
+  String mealDeleteComponentConfirmBody(Object componentKind) {
+    return 'The \"$componentKind\" course will be removed from this meal.';
+  }
 
   @override
   String get mealModeCooked => 'Home-cooked meal';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1913,6 +1913,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mealDeleteComponent => 'Supprimer ce composant';
 
   @override
+  String get mealDeleteComponentConfirmTitle => 'Supprimer ce composant ?';
+
+  @override
+  String mealDeleteComponentConfirmBody(Object componentKind) {
+    return 'Le composant « $componentKind » sera retiré de ce repas.';
+  }
+
+  @override
   String get mealModeCooked => 'Repas cuisiné';
 
   @override
@@ -4554,6 +4562,14 @@ class AppLocalizationsFrFr extends AppLocalizationsFr {
 
   @override
   String get mealDeleteComponent => 'Supprimer ce composant';
+
+  @override
+  String get mealDeleteComponentConfirmTitle => 'Supprimer ce composant ?';
+
+  @override
+  String mealDeleteComponentConfirmBody(Object componentKind) {
+    return 'Le composant « $componentKind » sera retiré de ce repas.';
+  }
 
   @override
   String get mealModeCooked => 'Repas cuisiné';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
En vue détail repas « On cuisine », la suppression d’une entrée, d’un plat ou d’un dessert ouvre désormais une boîte de dialogue qui rappelle le type de composant et demande confirmation. Cela évite les suppressions accidentelles lors d’un tap sur l’icône poubelle.

Les libellés sont ajoutés dans les fichiers ARB de référence (FR/EN).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc36ae66-d27c-49fa-8eb1-6a365f4e2569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc36ae66-d27c-49fa-8eb1-6a365f4e2569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

