### PR TITLE
feat(meals): confirmation avant suppression d’un apport (auberge espagnole)

### DIFF
--- a/lib/features/meals/presentation/trip_meal_details_page.dart
+++ b/lib/features/meals/presentation/trip_meal_details_page.dart
@@ -399,6 +399,36 @@ class _TripMealDetailsPageState extends ConsumerState<TripMealDetailsPage> {
     await _savePotluckItems(previousItems: previousItems);
   }
 
+  Future<void> _confirmDeletePotluckItem(int index) async {
+    final l10n = AppLocalizations.of(context)!;
+    if (index < 0 || index >= _potluckItems.length) return;
+    final item = _potluckItems[index];
+    final displayLabel = item.label.trim().isEmpty
+        ? l10n.mealPotluckItemLabel
+        : item.label.trim();
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(l10n.mealPotluckDeleteItemTitle),
+        content: Text(l10n.mealPotluckDeleteItemBody(displayLabel)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(l10n.commonCancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(l10n.commonDelete),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true || !mounted) return;
+    final resolvedIndex = _potluckItems.indexWhere((e) => e.id == item.id);
+    if (resolvedIndex < 0) return;
+    await _deletePotluckItem(resolvedIndex);
+  }
+
   Future<void> _deletePotluckItem(int index) async {
     final previousItems = _potluckItems;
     setState(() {
@@ -2383,7 +2413,7 @@ class _TripMealDetailsPageState extends ConsumerState<TripMealDetailsPage> {
                                                                 onPressed: _isSavingPotluckItems
                                                                     ? null
                                                                     : () =>
-                                                                        _deletePotluckItem(
+                                                                        _confirmDeletePotluckItem(
                                                                           entries[entryIndex]
                                                                               .key,
                                                                         ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -790,6 +790,13 @@
       }
     }
   },
+  "mealPotluckDeleteItemTitle": "Remove this item?",
+  "mealPotluckDeleteItemBody": "The \"{itemLabel}\" contribution will be removed from this meal.",
+  "@mealPotluckDeleteItemBody": {
+    "placeholders": {
+      "itemLabel": {}
+    }
+  },
   "commonSaving": "Saving...",
   "mealComponentKindEntree": "Starter",
   "mealComponentKindMain": "Main",

--- a/lib/l10n/app_en_US.arb
+++ b/lib/l10n/app_en_US.arb
@@ -752,6 +752,13 @@
       }
     }
   },
+  "mealPotluckDeleteItemTitle": "Remove this item?",
+  "mealPotluckDeleteItemBody": "The \"{itemLabel}\" contribution will be removed from this meal.",
+  "@mealPotluckDeleteItemBody": {
+    "placeholders": {
+      "itemLabel": {}
+    }
+  },
   "commonSaving": "Saving...",
   "mealComponentKindEntree": "Starter",
   "mealComponentKindMain": "Main",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -790,6 +790,13 @@
       }
     }
   },
+  "mealPotluckDeleteItemTitle": "Supprimer cet élément ?",
+  "mealPotluckDeleteItemBody": "« {itemLabel} » sera retiré de la liste des apports.",
+  "@mealPotluckDeleteItemBody": {
+    "placeholders": {
+      "itemLabel": {}
+    }
+  },
   "commonSaving": "Enregistrement...",
   "mealComponentKindEntree": "Entrée",
   "mealComponentKindMain": "Plat",

--- a/lib/l10n/app_fr_FR.arb
+++ b/lib/l10n/app_fr_FR.arb
@@ -752,6 +752,13 @@
       }
     }
   },
+  "mealPotluckDeleteItemTitle": "Supprimer cet élément ?",
+  "mealPotluckDeleteItemBody": "« {itemLabel} » sera retiré de la liste des apports.",
+  "@mealPotluckDeleteItemBody": {
+    "placeholders": {
+      "itemLabel": {}
+    }
+  },
   "commonSaving": "Enregistrement...",
   "mealComponentKindEntree": "Entrée",
   "mealComponentKindMain": "Plat",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3600,6 +3600,18 @@ abstract class AppLocalizations {
   /// **'{currentCount}/{maxCount} éléments ajoutés'**
   String mealPotluckCreateRowsHint(int currentCount, int maxCount);
 
+  /// No description provided for @mealPotluckDeleteItemTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Supprimer cet élément ?'**
+  String get mealPotluckDeleteItemTitle;
+
+  /// No description provided for @mealPotluckDeleteItemBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'« {itemLabel} » sera retiré de la liste des apports.'**
+  String mealPotluckDeleteItemBody(Object itemLabel);
+
   /// No description provided for @commonSaving.
   ///
   /// In fr, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1965,6 +1965,14 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get mealPotluckDeleteItemTitle => 'Remove this item?';
+
+  @override
+  String mealPotluckDeleteItemBody(Object itemLabel) {
+    return 'The \"$itemLabel\" contribution will be removed from this meal.';
+  }
+
+  @override
   String get commonSaving => 'Saving...';
 
   @override
@@ -4588,6 +4596,14 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
   @override
   String mealPotluckCreateRowsHint(int currentCount, int maxCount) {
     return '$currentCount/$maxCount items added';
+  }
+
+  @override
+  String get mealPotluckDeleteItemTitle => 'Remove this item?';
+
+  @override
+  String mealPotluckDeleteItemBody(Object itemLabel) {
+    return 'The \"$itemLabel\" contribution will be removed from this meal.';
   }
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1982,6 +1982,14 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get mealPotluckDeleteItemTitle => 'Supprimer cet élément ?';
+
+  @override
+  String mealPotluckDeleteItemBody(Object itemLabel) {
+    return '« $itemLabel » sera retiré de la liste des apports.';
+  }
+
+  @override
   String get commonSaving => 'Enregistrement...';
 
   @override
@@ -4630,6 +4638,14 @@ class AppLocalizationsFrFr extends AppLocalizationsFr {
   @override
   String mealPotluckCreateRowsHint(int currentCount, int maxCount) {
     return '$currentCount/$maxCount éléments ajoutés';
+  }
+
+  @override
+  String get mealPotluckDeleteItemTitle => 'Supprimer cet élément ?';
+
+  @override
+  String mealPotluckDeleteItemBody(Object itemLabel) {
+    return '« $itemLabel » sera retiré de la liste des apports.';
   }
 
   @override


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Sur l’écran de détail d’un repas en mode auberge espagnole, la suppression d’un élément de la liste ouvre désormais une boîte de dialogue de confirmation (Annuler / Supprimer) avec le libellé de l’élément concerné, afin d’éviter les suppressions accidentelles au toucher sur l’icône poubelle.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-935d960e-ba20-4d0b-bbd6-1671009d10f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-935d960e-ba20-4d0b-bbd6-1671009d10f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

