### PR TITLE
feat(shopping): confirmation avant suppression d’un article (menu …)

### DIFF
--- a/lib/features/shopping/presentation/widgets/shopping_item_row.dart
+++ b/lib/features/shopping/presentation/widgets/shopping_item_row.dart
@@ -61,6 +61,31 @@ class _ShoppingItemRowState extends ConsumerState<ShoppingItemRow> {
         );
   }
 
+  Future<void> _confirmAndDelete() async {
+    final l10n = AppLocalizations.of(context)!;
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(l10n.shoppingDeleteItemTitle),
+          content: Text(l10n.shoppingDeleteItemBody),
+          actions: [
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(l10n.commonCancel),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: Text(l10n.commonDelete),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirm != true || !mounted) return;
+    await _delete();
+  }
+
   Future<void> _toggleClaim() async {
     final user = FirebaseAuth.instance.currentUser;
     final uid = user?.uid.trim() ?? '';
@@ -113,7 +138,7 @@ class _ShoppingItemRowState extends ConsumerState<ShoppingItemRow> {
               quantityUnit: value.quantityUnit,
             );
       },
-      onDelete: _delete,
+      onDelete: _confirmAndDelete,
       autoFocusLabel: widget.autoFocusLabel,
       onAutoFocusHandled: widget.onAutoFocusHandled,
       isDuplicateLabel: _isDuplicateLabel,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -638,6 +638,8 @@
   "@shoppingDeleteCheckedContent": {"placeholders": {"count": {}}},
   "shoppingDeletedCount": "{count} item(s) deleted.",
   "@shoppingDeletedCount": {"placeholders": {"count": {}}},
+  "shoppingDeleteItemTitle": "Delete this item?",
+  "shoppingDeleteItemBody": "The item will be permanently deleted. This action cannot be undone.",
   "shoppingFilterHelpTooltip": "Filter help",
   "shoppingEmptyTitle": "Shopping list is empty",
   "shoppingEmptySubtitle": "Use the cart button to add an item.",

--- a/lib/l10n/app_en_US.arb
+++ b/lib/l10n/app_en_US.arb
@@ -600,6 +600,8 @@
   "@shoppingDeleteCheckedContent": {"placeholders": {"count": {}}},
   "shoppingDeletedCount": "{count} item(s) deleted.",
   "@shoppingDeletedCount": {"placeholders": {"count": {}}},
+  "shoppingDeleteItemTitle": "Delete this item?",
+  "shoppingDeleteItemBody": "The item will be permanently deleted. This action cannot be undone.",
   "shoppingFilterHelpTooltip": "Filter help",
   "shoppingEmptyTitle": "Shopping list is empty",
   "shoppingEmptySubtitle": "Use the cart button to add an item.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -638,6 +638,8 @@
   "@shoppingDeleteCheckedContent": {"placeholders": {"count": {}}},
   "shoppingDeletedCount": "{count} élément(s) supprimé(s).",
   "@shoppingDeletedCount": {"placeholders": {"count": {}}},
+  "shoppingDeleteItemTitle": "Supprimer cet article ?",
+  "shoppingDeleteItemBody": "L'article sera supprimé définitivement. Cette opération est irréversible.",
   "shoppingFilterHelpTooltip": "Aide des filtres",
   "shoppingEmptyTitle": "Liste de courses vide",
   "shoppingEmptySubtitle": "Utilisez le bouton panier pour ajouter un article.",

--- a/lib/l10n/app_fr_FR.arb
+++ b/lib/l10n/app_fr_FR.arb
@@ -600,6 +600,8 @@
   "@shoppingDeleteCheckedContent": {"placeholders": {"count": {}}},
   "shoppingDeletedCount": "{count} élément(s) supprimé(s).",
   "@shoppingDeletedCount": {"placeholders": {"count": {}}},
+  "shoppingDeleteItemTitle": "Supprimer cet article ?",
+  "shoppingDeleteItemBody": "L'article sera supprimé définitivement. Cette opération est irréversible.",
   "shoppingFilterHelpTooltip": "Aide des filtres",
   "shoppingEmptyTitle": "Liste de courses vide",
   "shoppingEmptySubtitle": "Utilisez le bouton panier pour ajouter un article.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2850,6 +2850,18 @@ abstract class AppLocalizations {
   /// **'{count} élément(s) supprimé(s).'**
   String shoppingDeletedCount(Object count);
 
+  /// No description provided for @shoppingDeleteItemTitle.
+  ///
+  /// In fr, this message translates to:
+  /// **'Supprimer cet article ?'**
+  String get shoppingDeleteItemTitle;
+
+  /// No description provided for @shoppingDeleteItemBody.
+  ///
+  /// In fr, this message translates to:
+  /// **'L\'article sera supprimé définitivement. Cette opération est irréversible.'**
+  String get shoppingDeleteItemBody;
+
   /// No description provided for @shoppingFilterHelpTooltip.
   ///
   /// In fr, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1550,6 +1550,13 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get shoppingDeleteItemTitle => 'Delete this item?';
+
+  @override
+  String get shoppingDeleteItemBody =>
+      'The item will be permanently deleted. This action cannot be undone.';
+
+  @override
   String get shoppingFilterHelpTooltip => 'Filter help';
 
   @override
@@ -4174,6 +4181,13 @@ class AppLocalizationsEnUs extends AppLocalizationsEn {
   String shoppingDeletedCount(Object count) {
     return '$count item(s) deleted.';
   }
+
+  @override
+  String get shoppingDeleteItemTitle => 'Delete this item?';
+
+  @override
+  String get shoppingDeleteItemBody =>
+      'The item will be permanently deleted. This action cannot be undone.';
 
   @override
   String get shoppingFilterHelpTooltip => 'Filter help';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1566,6 +1566,13 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get shoppingDeleteItemTitle => 'Supprimer cet article ?';
+
+  @override
+  String get shoppingDeleteItemBody =>
+      'L\'article sera supprimé définitivement. Cette opération est irréversible.';
+
+  @override
   String get shoppingFilterHelpTooltip => 'Aide des filtres';
 
   @override
@@ -4215,6 +4222,13 @@ class AppLocalizationsFrFr extends AppLocalizationsFr {
   String shoppingDeletedCount(Object count) {
     return '$count élément(s) supprimé(s).';
   }
+
+  @override
+  String get shoppingDeleteItemTitle => 'Supprimer cet article ?';
+
+  @override
+  String get shoppingDeleteItemBody =>
+      'L\'article sera supprimé définitivement. Cette opération est irréversible.';
 
   @override
   String get shoppingFilterHelpTooltip => 'Aide des filtres';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
La suppression d’une ligne depuis le menu « … » sur chaque article de la liste de courses ouvre désormais une boîte de dialogue de confirmation (même disposition que pour la suppression des éléments cochés : Annuler en action principale, Supprimer en secondaire). Le texte est entièrement localisé (FR/EN).

Aucun déploiement Firebase requis.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18561a92-ccc6-42dd-a76f-0a578e9e6699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18561a92-ccc6-42dd-a76f-0a578e9e6699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

